### PR TITLE
修复File缓存方式下，clear报错误

### DIFF
--- a/library/think/cache/driver/File.php
+++ b/library/think/cache/driver/File.php
@@ -186,18 +186,11 @@ class File
      */
     public function clear()
     {
-        $path = $this->options['path'];
-        if ($dir = opendir($path)) {
-            while ($file = readdir($dir)) {
-                $check = is_dir($file);
-                if (!$check) {
-                    $this->unlink($path . $file);
-                }
-
-            }
-            closedir($dir);
-            return true;
+        $fileLsit = (array)glob($this->options['path'].'*');
+        foreach ($fileLsit as $path) {
+            is_file($path) && unlink($path);
         }
+        return true;
     }
 
     /**


### PR DESCRIPTION
linux可能出现 . 或者 .. 特殊目录，在进行is_dir时，会报错