### PR TITLE
分组路由中 不能解析非数组配置的问题

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -163,7 +163,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 $item[$key] = $data;
             } else {
                 // 模型属性
-                $item[$key] = $this->$key;
+                $item[$key] = $this->__get($key);
             }
         }
         return !empty($item) ? $item : [];

--- a/library/think/Url.php
+++ b/library/think/Url.php
@@ -255,7 +255,9 @@ class Url
                     if (is_numeric($key)) {
                         $key = array_shift($route);
                     }
-                    $route = $route[0];
+                    if (is_array($route)) {
+                        $route = $route[0];
+                    }
                     $param = [];
                     if (is_array($route)) {
                         $route = implode('\\', $route);

--- a/tests/application/route.php
+++ b/tests/application/route.php
@@ -15,6 +15,7 @@ return [
         'name' => '\w+',
     ],
     '[hello]'     => [
+        'str'   => 'index/str',
         ':id'   => ['index/hello', ['method' => 'get'], ['id' => '\d+']],
         ':name' => ['index/hello', ['method' => 'post']],
     ],

--- a/tests/application/route.php
+++ b/tests/application/route.php
@@ -15,9 +15,9 @@ return [
         'name' => '\w+',
     ],
     '[hello]'     => [
-        'str'   => 'index/str',
-        ':id'   => ['index/hello', ['method' => 'get'], ['id' => '\d+']],
-        ':name' => ['index/hello', ['method' => 'post']],
+        'str'               => 'index/str',
+        'hello-<name><id?>' => 'index/say',
+        ':id'               => ['index/hello', ['method' => 'get'], ['id' => '\d+']],
+        ':name'             => ['index/hello', ['method' => 'post']],
     ],
-
 ];

--- a/tests/thinkphp/library/think/urlTest.php
+++ b/tests/thinkphp/library/think/urlTest.php
@@ -37,6 +37,8 @@ class urlTest extends \PHPUnit_Framework_TestCase
         Route::get('hello-<name><id?>', 'index/say');
         $this->assertEquals('/hello-thinkphp', Url::build('index/say?name=thinkphp'));
         $this->assertEquals('/hello-thinkphp2016', Url::build('index/say?name=thinkphp&id=2016'));
+        Route::get('str', 'index/str');
+        $this->assertEquals('/hello/str.html', Url::build('index/str', '', 'html'));
     }
 
     public function testBuildController()


### PR DESCRIPTION
原
'[system]'    => [
    'login'  => ['system/login/index', []],
],
现
'[system]'    => [
    'login'  => 'system/login/index',
],