### PR TITLE
修改在使用域名路由时，url方法结果不正确的bug(优化parseDomain)

### DIFF
--- a/library/think/Url.php
+++ b/library/think/Url.php
@@ -150,22 +150,26 @@ class Url
                 if (Config::get('url_domain_deploy')) {
                     // 根域名
                     $urlDomainRoot = Config::get('url_domain_root');
-                    foreach (Route::domain() as $key => $rule) {
-                        $rule = is_array($rule) ? $rule[0] : $rule;
-                        if (false === strpos($key, '*') && 0 === strpos($url, $rule)) {
-                            $url    = ltrim($url, $rule);
-                            $domain = $key;
-                            // 生成对应子域名
-                            if(!empty($urlDomainRoot)){
-                                $domain .= $urlDomainRoot;
+                    $route_domain = array_keys(Route::domain());
+                    foreach($route_domain as $domain_prefix) {
+                        if(strpos($domain, trim($domain_prefix, '*.')) !== false) {
+                            foreach (Route::domain() as $key => $rule) {
+                                $rule = is_array($rule) ? $rule[0] : $rule;
+                                if (false === strpos($key, '*') && 0 === strpos($url, $rule)) {
+                                    $url    = ltrim($url, $rule);
+                                    $domain = $key;
+                                    // 生成对应子域名
+                                    if(!empty($urlDomainRoot)){
+                                        $domain .= $urlDomainRoot;
+                                    }
+                                    break;
+                                }else if(false !== strpos($key, '*')){
+                                    if(!empty($urlDomainRoot)){
+                                        $domain .= $urlDomainRoot;
+                                    }
+                                    break;
+                                }
                             }
-                            break;
-                        }else if(false !== strpos($key, '*')){
-                            $domain = str_replace('*',strstr($domain,'.',true),$key);
-                            if(!empty($urlDomainRoot)){
-                                $domain .= $urlDomainRoot;
-                            }
-                            break;
                         }
                     }
                 }


### PR DESCRIPTION
不知道我这改合不合适，流年可以试一下 在开启 域名路由的时候url 的输出结果，我这边测试有bug就改了

// 域名部署
'url_domain_deploy'      => true,  // 域名部署
// 域名路由
'domain' => [
'admin' => 'admin',
'api' => 'api',
'store' => 'store',
'supplier' => 'supplier',
'.store' => 'store',
'.supplier' => 'supplier',
],

然后通过 store.test.com www.test.com 对应的 index 控制器 输出 url('index'); 有问题， 可以测试一下看看然后再决定是否合并