### PR TITLE
优化set修改器，$data不完整

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -256,7 +256,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         if (!empty($data)) {
             // 数据对象赋值
             foreach ($data as $key => $value) {
-                $this->__set($key, $value);
+                $this->__set($key, $value, $data);
             }
             if (!empty($where)) {
                 $this->isUpdate = true;
@@ -914,9 +914,10 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
      * @access public
      * @param string $name 名称
      * @param mixed $value 值
+     * @param array $data 数据信息
      * @return void
      */
-    public function __set($name, $value)
+    public function __set($name, $value, $data = [])
     {
         if (is_null($value) && in_array($name, $this->autoTimeField)) {
             // 自动写入的时间戳字段
@@ -943,7 +944,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
             // 检测修改器
             $method = 'set' . Loader::parseName($name, 1) . 'Attr';
             if (method_exists($this, $method)) {
-                $value = $this->$method($value, $this->data);
+                $value = $this->$method($value, array_merge($data, $this->data));
             } elseif (isset($this->type[$name])) {
                 // 类型转换
                 $type = $this->type[$name];


### PR DESCRIPTION
经常遇到的坑是：
比如新增 a b c d 4个字段内容，进行新增操作调用save方法。由于save对$data是进行遍历调用修改器，导致当前对象的$this->data并不完整。例如b字段是和d字段有一定关联关系的，因为是foreach的方式，导致执行到d的修改器时，压根在$data参数获取不到d的值！，虽然可以在修改器里，直接获取外部提交的变量，但这种方式，不完美！如果我不是外部获取的数据呢？那岂不是没辙了！