### PR TITLE
default_ajax_return 的默认值应该为json小写

### DIFF
--- a/convention.php
+++ b/convention.php
@@ -20,7 +20,7 @@ return [
     // response是否返回方式
     'response_return'        => false,
     // 默认AJAX 数据返回格式,可选JSON XML ...
-    'default_ajax_return'    => 'JSON',
+    'default_ajax_return'    => 'json',
     // 默认JSONP格式返回的处理方法
     'default_jsonp_handler'  => 'jsonpReturn',
     // 默认JSONP处理方法


### PR DESCRIPTION
default_ajax_return 的默认值JSON应改为json，否则\library\traits\controller\Jump.php[108]
会出现Undefined variable: response的错误