### PR TITLE
修正selectInsert方法字段数不一致错误

### DIFF
--- a/library/think/db/builder/Sqlsrv.php
+++ b/library/think/db/builder/Sqlsrv.php
@@ -19,6 +19,7 @@ use think\db\Builder;
 class Sqlsrv extends Builder
 {
     protected $selectSql = 'SELECT T1.* FROM (SELECT thinkphp.*, ROW_NUMBER() OVER (%ORDER%) AS ROW_NUMBER FROM (SELECT %DISTINCT% %FIELD% FROM %TABLE%%JOIN%%WHERE%%GROUP%%HAVING%) AS thinkphp) AS T1 %LIMIT%%COMMENT%';
+    protected $selectInsertSql = 'SELECT %DISTINCT% %FIELD% FROM %TABLE%%JOIN%%WHERE%%GROUP%%HAVING%';
     protected $updateSql = 'UPDATE %TABLE% SET %SET% %JOIN% %WHERE% %LIMIT% %LOCK%%COMMENT%';
     protected $deleteSql = 'DELETE FROM %TABLE% %USING% %JOIN% %WHERE% %LIMIT% %LOCK%%COMMENT%';
 
@@ -77,6 +78,11 @@ class Sqlsrv extends Builder
             $limitStr = '(T1.ROW_NUMBER BETWEEN 1 AND ' . $limit[0] . ")";
         }
         return 'WHERE ' . $limitStr;
+    }
+     public function selectInsert($fields, $table, $options)
+    {
+        $this->selectSql=$this->selectInsertSql;
+        return parent::selectInsert($fields, $table, $options);
     }
 
 }


### PR DESCRIPTION
mssql中为实现排序增加了row_number列，导致在selectInsert方法中字段数不一致。
修正方法：定义selectInsertSql属性，重写selectInsert方法。