### PR TITLE
修正了Memcached关闭时调用的方法。

### DIFF
--- a/library/think/session/driver/Memcached.php
+++ b/library/think/session/driver/Memcached.php
@@ -64,7 +64,7 @@ class Memcached extends SessionHandler
         if('' != $this->config['username']){
             $this->handler->setOption(\Memcached::OPT_BINARY_PROTOCOL, true);
             $this->handler->setSaslAuthData($this->config['username'], $this->config['password']);	
-		}
+        }
         return true;
     }
 
@@ -75,7 +75,7 @@ class Memcached extends SessionHandler
     public function close()
     {
         $this->gc(ini_get('session.gc_maxlifetime'));
-        $this->handler->close();
+        $this->handler->quit();
         $this->handler = null;
         return true;
     }


### PR DESCRIPTION
Memcached在关闭时与Memcache调用的方法不同，应该使用quit方法进行关闭所有连接的操作。此前使用错了关闭方法，导致在操作session的时候服务器返回500错误。

详见：http://php.net/manual/en/memcached.quit.php