### PR TITLE
修正$dataSet不存在索引0导致异常的情况

### DIFF
--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -1610,7 +1610,7 @@ class Query
     {
         // 分析查询表达式
         $options = $this->parseExpress();
-        if (!is_array($dataSet[0])) {
+        if (!is_array(reset($dataSet))) {
             return false;
         }
         // 生成SQL语句


### PR DESCRIPTION
当$dataSet不包含索引0的时候，会抛出异常，如：$dataSet = [1=>[……],'str'=>[……],……];