### PR TITLE
修正MYSQL UPDATE JOIN语法错误

### DIFF
--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -34,7 +34,7 @@ abstract class Builder
     protected $selectSql    = 'SELECT%DISTINCT% %FIELD% FROM %TABLE%%FORCE%%JOIN%%WHERE%%GROUP%%HAVING%%ORDER%%LIMIT% %UNION%%LOCK%%COMMENT%';
     protected $insertSql    = '%INSERT% INTO %TABLE% (%FIELD%) VALUES (%DATA%) %COMMENT%';
     protected $insertAllSql = 'INSERT INTO %TABLE% (%FIELD%) %DATA% %COMMENT%';
-    protected $updateSql    = 'UPDATE %TABLE% SET %SET% %JOIN% %WHERE% %ORDER%%LIMIT% %LOCK%%COMMENT%';
+    protected $updateSql    = 'UPDATE %TABLE% %JOIN% SET %SET% %WHERE% %ORDER%%LIMIT% %LOCK%%COMMENT%';
     protected $deleteSql    = 'DELETE FROM %TABLE% %USING% %JOIN% %WHERE% %ORDER%%LIMIT% %LOCK%%COMMENT%';
 
     /**


### PR DESCRIPTION
修正MYSQL UPDATE JOIN语法错误，DELETE JOIN仍然有错误,需要新增支持。
正确的语法应该是：DELETE aliasA,aliasB FROM tableA aliasA INNER JOIN tableB aliasB ON aliasA.id = aliasB.id WHERE id=1