### PR TITLE
读取时增加空检测，防止数据为空导致调用异常

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -391,11 +391,13 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 $value  = date($format, strtotime($value));
                 break;
             case 'json':
-            case 'array':
                 $value = json_decode($value, true);
                 break;
+            case 'array':
+                $value = is_null($value) ? [] : json_decode($value, true);
+                break;
             case 'object':
-                $value = json_decode($value);
+                $value = empty($value) ? new \stdClass() : json_decode($value);
                 break;
             case 'serialize':
                 $value = unserialize($value);


### PR DESCRIPTION
防止array和object类型数据为null时，导致调用发生异常。