### PR TITLE
修正过期时间问题

### DIFF
--- a/library/think/session/driver/Memcached.php
+++ b/library/think/session/driver/Memcached.php
@@ -98,7 +98,7 @@ class Memcached extends SessionHandler
      */
     public function write($sessID, $sessData)
     {
-        return $this->handler->set($this->config['session_name'] . $sessID, $sessData, $this->config['expire']);
+        return $this->handler->set($this->config['session_name'] . $sessID, $sessData, $this->config['expire']/1000);
     }
 
     /**


### PR DESCRIPTION
经测试，memcached的过期时间单位是秒，而非毫秒，但是在配置描述中所要求的填写的时间单位是毫秒，所以在此处理一下时间单位问题。