### PR TITLE
增加了连接memcached时账号密码的属性、修正了缓存时间单位问题

### DIFF
--- a/library/think/cache/driver/Memcached.php
+++ b/library/think/cache/driver/Memcached.php
@@ -23,6 +23,8 @@ class Memcached
         'expire'  => 0,
         'timeout' => 0, // 超时时间（单位：毫秒）
         'prefix'  => '',
+        'username'     => '', //账号
+        'password'     => '', //密码
     ];
 
     /**
@@ -55,6 +57,10 @@ class Memcached
             $servers[] = [$host, (isset($ports[$i]) ? $ports[$i] : $ports[0]), 1];
         }
         $this->handler->addServers($servers);
+        if('' != $this->options['username']){
+            $this->handler->setOption(\Memcached::OPT_BINARY_PROTOCOL, true);
+            $this->handler->setSaslAuthData($this->options['username'], $this->options['password']);  
+        }
     }
 
     /**
@@ -79,7 +85,7 @@ class Memcached
     public function set($name, $value, $expire = null)
     {
         if (is_null($expire)) {
-            $expire = $this->options['expire'];
+            $expire = $this->options['expire'] / 1000;
         }
         $name   = $this->options['prefix'] . $name;
         $expire = 0 == $expire ? 0 : time() + $expire;


### PR DESCRIPTION
1.增加了连接memcached时账号密码的属性
2.经测试，memcached的过期时间单位是秒，而非毫秒，但是在配置描述中所要求的填写的时间单位是毫秒，所以在此处理一下时间单位问题。