### PR TITLE
修正scope方法$name为['']时引起死循环，新增关联数组传入参数支持

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -988,6 +988,8 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     {
         if ($name instanceof Query) {
             return $name;
+        }elseif (is_string($name)) {
+            return self::scope(explode(',', $name));
         }
         $model = new static();
         $params = func_get_args();
@@ -996,12 +998,18 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
             call_user_func_array($name, $params);
         } elseif (is_string($name)) {
             $name = explode(',', $name);
-        }
-        if (is_array($name)) {
-            foreach ($name as $scope) {
-                $method = 'scope' . trim($scope);
-                if (method_exists($model, $method)) {
-                    call_user_func_array([$model, $method], $params);
+        }elseif (is_array($name)) {
+            foreach ($name as $key => $scope) {
+                if (is_int($key)) {
+                    $args = $params;
+                    $scope = trim($scope);
+                } else {
+                    $args = array_merge([$params[0]], (array) $scope);
+                    $scope = trim($key);
+                }
+                $method = 'scope' . ucfirst($scope);
+                if (!empty($scope) && method_exists($model, $method)) {
+                    call_user_func_array([$model, $method], $args);
                 }
             }
         }


### PR DESCRIPTION
1.修正scope方法$name为['']时引起死循环；
2.新增关联数组传入时，键为名值为参；
用例：
model('Name')->scope([
    'user' => 1, //执行scopeUser($query,1),
    'recent' => ['param1', 'param2', 'param3'], //执行scopeRecent($query,'param1', 'param2', 'param3'),
    '' => '这条将被忽略',
    '', //这条也将被忽略
    ' ', //这条也将被忽略
    null, //这条也将被忽略
    0, //这条也将被忽略
]);
model('Name')->scope('testA,testA,testC, ');
//scopeTesta($query)->scopeTestb($query)->scopeTestc($query),最后的一个空将被忽略