### PR TITLE
修正一处路由解析错误

### DIFF
--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -670,7 +670,18 @@ class Route
         if ($checkDomain) {
             self::checkDomain($request);
         }
-
+        
+        // 获取当前请求类型的路由规则
+        $rules = self::$rules[$request->method()];
+        if (isset($rules[$url])) {
+            // 静态路由规则检测
+            $rule = $rules[$url];
+            if (true === $rule) {
+                $rule = self::$rules['*'][$url];
+            }
+            return self::parseRule($url, $rule['route'], $url, $rule['option']);
+        }
+        
         // 检测URL绑定
         $return = self::checkUrlBind($url, $rules, $depr);
         if (false !== $return) {

--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -670,18 +670,18 @@ class Route
         if ($checkDomain) {
             self::checkDomain($request);
         }
-        
-        // 获取当前请求类型的路由规则
-        $rules = self::$rules[$request->method()];
-        if (isset($rules[$url])) {
-            // 静态路由规则检测
-            $rule = $rules[$url];
-            if (true === $rule) {
-                $rule = self::$rules['*'][$url];
+        if(strpos($url,'/')===false)(
+            // 获取当前请求类型的路由规则
+            $rules = self::$rules[$request->method()];
+            if (isset($rules[$url])) {
+                // 静态路由规则检测
+                $rule = $rules[$url];
+                if (true === $rule) {
+                    $rule = self::$rules['*'][$url];
+                }
+                return self::parseRule($url, $rule['route'], $url, $rule['option']);
             }
-            return self::parseRule($url, $rule['route'], $url, $rule['option']);
-        }
-        
+        )
         // 检测URL绑定
         $return = self::checkUrlBind($url, $rules, $depr);
         if (false !== $return) {

--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -670,7 +670,7 @@ class Route
         if ($checkDomain) {
             self::checkDomain($request);
         }
-        if(strpos($url,'/')===false)(
+        if(strpos($url,'/')===false){
             // 获取当前请求类型的路由规则
             $rules = self::$rules[$request->method()];
             if (isset($rules[$url])) {
@@ -681,7 +681,7 @@ class Route
                 }
                 return self::parseRule($url, $rule['route'], $url, $rule['option']);
             }
-        )
+        }
         // 检测URL绑定
         $return = self::checkUrlBind($url, $rules, $depr);
         if (false !== $return) {


### PR DESCRIPTION
案例 朋友定义了这样的的路由
```
\think\Route::rule([
    // 用户登录
    'signin'           => ['user/customers/signin', ['method' => 'GET|POST']],
    // 用户注册
    'signup'           => ['user/customers/signup', ['method' => 'GET|POST']],
    // 注册短信
    'signup/sms'       => ['user/customers/sms', ['method' => 'POST']],
    // 找回密码
    'forgot'           => ['user/customers/forgot', ['method' => 'GET|POST']],
    // 退出登录
    'logout'           => ['user/customers/logout', ['method' => 'GET']],
]);
```
在访问http://url/sign的时候 发现 sign控制器不存在，于是发现因为APP::chekUrlBind 将url给更改为user/signin 导致错误。
在不妨碍原逻辑下，这样修改比较保守，但是不排除会遇到其他的问题