### PR TITLE
改进自动完成对类型转换的支持

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -332,7 +332,9 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 $value = (bool) $value;
                 break;
             case 'timestamp':
-                if (!is_numeric($value)) {
+                if (is_null($value)){
+                    $value = $_SERVER['REQUEST_TIME'];
+                }elseif (!is_numeric($value)){
                     $value = strtotime($value);
                 }
                 break;


### PR DESCRIPTION
在没有自动写时间戳情况下
```
    //类型转换
    protected $type = [
        'update_time'  =>  'timestamp',
    ];
    //自动完成
    protected $auto = [ 'update_time'];
```
update_time为空的时候获取当前时间戳