### PR TITLE
修正了延迟递增减后不能清空的计数的问题、修正了延迟递减，数值小于零时不能递减的问题

### DIFF
--- a/library/think/cache/driver/Memcached.php
+++ b/library/think/cache/driver/Memcached.php
@@ -115,7 +115,7 @@ class Memcached
      */
     public function inc($name, $step = 1)
     {
-        return $this->handler->increment($name, $step);
+        return $this->handler->increment($this->options['prefix'] . $name, $step);
     }
 
     /**
@@ -127,7 +127,14 @@ class Memcached
      */
     public function dec($name, $step = 1)
     {
-        return $this->handler->decrement($name, $step);
+        $oldValue = $this->handler->get($this->options['prefix'] . $name);
+        $value    = $oldValue - $step;
+        $res      = $this->handler->set($this->options['prefix'] . $name, $oldValue - $step);
+        if (!$res) {
+            return false;
+        } else {
+            return $value;
+        }
     }
 
     /**

--- a/library/think/cache/driver/Memcached.php
+++ b/library/think/cache/driver/Memcached.php
@@ -115,7 +115,14 @@ class Memcached
      */
     public function inc($name, $step = 1)
     {
-        return $this->handler->increment($this->options['prefix'] . $name, $step);
+        $oldValue = $this->handler->get($this->options['prefix'] . $name);
+        $value    = $oldValue + $step;
+        $res      = $this->handler->set($this->options['prefix'] . $name, $value);
+        if (!$res) {
+            return false;
+        } else {
+            return $value;
+        }
     }
 
     /**
@@ -129,7 +136,7 @@ class Memcached
     {
         $oldValue = $this->handler->get($this->options['prefix'] . $name);
         $value    = $oldValue - $step;
-        $res      = $this->handler->set($this->options['prefix'] . $name, $oldValue - $step);
+        $res      = $this->handler->set($this->options['prefix'] . $name, $value);
         if (!$res) {
             return false;
         } else {


### PR DESCRIPTION
1.之前由于递增减的键值对的键是没有加前缀的，而移除这个记录增减的键值对时移除的是加前缀的，所以会导致移除时失败，最终造成递增减数值错误。
2.由于Memcached的decrement方法递减到0以后就不会再减小了，所以这里就会造成递减的数值不对。只好自己写一个递减的方法了。
该方法说明详见http://php.net/manual/zh/memcached.decrement.php