### PR TITLE
修正“isMobile”方法，防止在特殊情况下崩溃

### DIFF
--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -1228,7 +1228,7 @@ class Request
     {
         if (isset($_SERVER['HTTP_VIA']) && stristr($_SERVER['HTTP_VIA'], "wap")) {
             return true;
-        } elseif (strpos(strtoupper($_SERVER['HTTP_ACCEPT']), "VND.WAP.WML")) {
+        } elseif (isset($_SERVER['HTTP_ACCEPT']) && strpos(strtoupper($_SERVER['HTTP_ACCEPT']), "VND.WAP.WML")) {
             return true;
         } elseif (isset($_SERVER['HTTP_X_WAP_PROFILE']) || isset($_SERVER['HTTP_PROFILE'])) {
             return true;


### PR DESCRIPTION
若HTTP请求中HTTP_ACCEPT参数缺失会导致页面错误，因此首先需要判断一下该参数是否存在