### PR TITLE
计算吞吐率出现的'Division by zero'异常

### DIFF
--- a/library/think/log/driver/File.php
+++ b/library/think/log/driver/File.php
@@ -58,7 +58,7 @@ class File
         }
 
         $runtime    = number_format(microtime(true) - THINK_START_TIME, 10);
-        $reqs       = number_format(1 / $runtime, 2);
+        $reqs       = $runtime > 0 ? number_format(1 / $runtime, 2) : '∞';
         $time_str   = ' [运行时间：' . number_format($runtime, 6) . 's][吞吐率：' . $reqs . 'req/s]';
         $memory_use = number_format((memory_get_usage() - THINK_START_MEM) / 1024, 2);
         $memory_str = ' [内存消耗：' . $memory_use . 'kb]';

--- a/library/think/log/driver/Socket.php
+++ b/library/think/log/driver/Socket.php
@@ -64,7 +64,7 @@ class Socket
             return false;
         }
         $runtime    = number_format(microtime(true) - THINK_START_TIME, 10);
-        $reqs       = number_format(1 / $runtime, 2);
+        $reqs       = $runtime > 0 ? number_format(1 / $runtime, 2) : '∞';
         $time_str   = ' [运行时间：' . number_format($runtime, 6) . 's][吞吐率：' . $reqs . 'req/s]';
         $memory_use = number_format((memory_get_usage() - THINK_START_MEM) / 1024, 2);
         $memory_str = ' [内存消耗：' . $memory_use . 'kb]';


### PR DESCRIPTION
修复$runtime为0时,计算吞吐率出现'Division by zero'异常，错误信息：
``Fatal error: Uncaught exception 'think\exception\ErrorException' with message 'Division by zero'