### PR TITLE
解决Linux环境下多级控制器URL区分大小写的BUG

### DIFF
--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -1138,7 +1138,8 @@ class Route
                 $item   = [];
                 foreach ($path as $val) {
                     $item[] = array_shift($path);
-                    if (is_file($dir . DS . $val . $suffix . EXT)) {
+                    $name = Loader::parseName($val, 1);
+                    if (is_file($dir . DS . $name . $suffix . EXT)) {
                         break;
                     } else {
                         $dir .= DS . $val;


### PR DESCRIPTION
解决Linux环境下，当controller_auto_search和url_convert设置为true之后，多级控制器的URL区分大小写的BUG。