### PR TITLE
增加cache/session redis驱动的库选择 fixed #253

### DIFF
--- a/library/think/cache/driver/Redis.php
+++ b/library/think/cache/driver/Redis.php
@@ -27,6 +27,7 @@ class Redis extends Driver
         'host'       => '127.0.0.1',
         'port'       => 6379,
         'password'   => '',
+        'select'     => 0,
         'timeout'    => 0,
         'expire'     => 0,
         'persistent' => false,
@@ -52,6 +53,10 @@ class Redis extends Driver
 
         if ('' != $this->options['password']) {
             $this->handler->auth($this->options['password']);
+        }
+
+        if (0 != $this->options['select']) {
+            $this->handler->select($this->options['select']);
         }
     }
 

--- a/library/think/session/driver/Redis.php
+++ b/library/think/session/driver/Redis.php
@@ -22,6 +22,7 @@ class Redis extends SessionHandler
         'host'         => '127.0.0.1', // redis主机
         'port'         => 6379, // redis端口
         'password'     => '', // 密码
+        'select'       => 0, // 操作库
         'expire'       => 3600, // 有效期(秒)
         'timeout'      => 0, // 超时时间(秒)
         'persistent'   => true, // 是否长连接
@@ -56,6 +57,11 @@ class Redis extends SessionHandler
         if ('' != $this->config['password']) {
             $this->handler->auth($this->config['password']);
         }
+
+        if (0 != $this->config['select']) {
+            $this->handler->select($this->config['select']);
+        }
+
         return true;
     }
 


### PR DESCRIPTION
* 增加cache/session redis驱动的库选择逻辑;
* hint: 需要在缓存配置(cache节点)中增加'select';
* eg: ['cache' => ['select'=>0, ...]];