### PR TITLE
pgsql主键命名

### DIFF
--- a/library/think/db/connector/Pgsql.php
+++ b/library/think/db/connector/Pgsql.php
@@ -61,7 +61,7 @@ class Pgsql extends Connection
                     'type'    => $val['type'],
                     'notnull' => (bool) ('' === $val['null']), // not null is empty, null is yes
                     'default' => $val['default'],
-                    'primary' => (strtolower($val['key']) == 'pri'),
+                    'primary' => (strtolower($val['key']) == $tableName.'_pkey'),
                     'autoinc' => (strtolower($val['extra']) == 'auto_increment'),
                 ];
             }


### PR DESCRIPTION
pgsql主键默认命名方式为 表名_pkey