### PR TITLE
解决 php7 数组指针问题

### DIFF
--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -974,6 +974,7 @@ class Request
         $filter[] = $default;
         if (is_array($data)) {
             array_walk_recursive($data, [$this, 'filterValue'], $filter);
+            reset($data);
         } else {
             $this->filterValue($data, $name, $filter);
         }


### PR DESCRIPTION
数组存在key()方法无法正确获得预定值