### PR TITLE
行为类代码改进

### DIFF
--- a/library/think/Hook.php
+++ b/library/think/Hook.php
@@ -128,7 +128,7 @@ class Hook
         }
         if (App::$debug) {
             Debug::remark('behavior_end', 'time');
-            if ($class instanceof \Closure) {
+            if (is_callable($class)) {
                 $class = 'Closure';
             } elseif (is_object($class)) {
                 $class = get_class($class);


### PR DESCRIPTION
1.改进get方法：防止数组索引未定义的异常
2.改进listen方法：$once=true的时候有可能没有日志记录；返回最后一条执行结果。
3.改进add方法：允许callable形式添加
4.修改exec方法：日志记录由listen转到exec，改为is_callable检查