### PR TITLE
Hook类代码改进

### DIFF
--- a/library/think/Hook.php
+++ b/library/think/Hook.php
@@ -1,4 +1,5 @@
 <?php
+
 // +----------------------------------------------------------------------
 // | ThinkPHP [ WE CAN DO IT JUST THINK ]
 // +----------------------------------------------------------------------
@@ -18,135 +19,112 @@ use think\Log;
 class Hook
 {
 
-    private static $tags = [];
+	private static $tags = [];
 
-    /**
-     * 动态添加行为扩展到某个标签
-     * @param string    $tag 标签名称
-     * @param mixed     $behavior 行为名称
-     * @param bool      $first 是否放到开头执行
-     * @return void
-     */
-    public static function add($tag, $behavior, $first = false)
-    {
-        if (!isset(self::$tags[$tag])) {
-            self::$tags[$tag] = [];
-        }
-        if (is_array($behavior)) {
-            self::$tags[$tag] = array_merge(self::$tags[$tag], $behavior);
-        } elseif ($first) {
-            array_unshift(self::$tags[$tag], $behavior);
-        } else {
-            self::$tags[$tag][] = $behavior;
-        }
-    }
+	/**
+	 * 动态添加行为扩展到某个标签
+	 * @param string    $tag 标签名称
+	 * @param mixed     $behavior 行为名称
+	 * @param bool      $first 是否放到开头执行
+	 * @return void
+	 */
+	public static function add($tag, $behavior, $first = false)
+	{
+		isset(self::$tags[$tag]) || self::$tags[$tag] = [];
+		if (is_array($behavior) && !is_callable($behavior)) {
+			if (!array_key_exists('_overlay', $behavior) || !$behavior['_overlay']) {
+				unset($behavior['_overlay']);
+				self::$tags[$tag] = array_merge(self::$tags[$tag], $behavior);
+			} else {
+				unset($behavior['_overlay']);
+				self::$tags[$tag] = $behavior;
+			}
+		} elseif ($first) {
+			array_unshift(self::$tags[$tag], $behavior);
+		} else {
+			self::$tags[$tag][] = $behavior;
+		}
+	}
 
-    /**
-     * 批量导入插件
-     * @param array    $tags 插件信息
-     * @param boolean $recursive 是否递归合并
-     */
-    public static function import($tags, $recursive = true)
-    {
-        empty($tags) && $tags = [];
-        if (!$recursive) {
-            // 覆盖导入
-            self::$tags = array_merge(self::$tags, $tags);
-        } else {
-            // 合并导入
-            foreach ($tags as $tag => $val) {
-                if (!isset(self::$tags[$tag])) {
-                    self::$tags[$tag] = [];
-                }
+	/**
+	 * 批量导入插件
+	 * @param array    $tags 插件信息
+	 * @param boolean $recursive 是否递归合并
+	 */
+	public static function import(array $tags, $recursive = true)
+	{
+		if ($recursive) {
+			foreach ($tags as $tag => $behavior) {
+				self::add($tag, $behavior);
+			}
+		} else {
+			self::$tags = $tags + self::$tags;
+		}
+	}
 
-                if (!empty($val['_overlay'])) {
-                    // 可以针对某个标签指定覆盖模式
-                    unset($val['_overlay']);
-                    self::$tags[$tag] = $val;
-                } else {
-                    // 合并模式
-                    self::$tags[$tag] = array_merge(self::$tags[$tag], $val);
-                }
-            }
-        }
-    }
+	/**
+	 * 获取插件信息
+	 * @param string $tag 插件位置 留空获取全部
+	 * @return array
+	 */
+	public static function get($tag = '')
+	{
+		if (empty($tag)) {//获取全部的插件信息
+			return self::$tags;
+		} else {
+			return array_key_exists($tag, self::$tags) ? self::$tags[$tag] : [];
+		}
+	}
 
-    /**
-     * 获取插件信息
-     * @param string $tag 插件位置 留空获取全部
-     * @return array
-     */
-    public static function get($tag = '')
-    {
-        if (empty($tag)) {
-            // 获取全部的插件信息
-            return self::$tags;
-        } else {
-            return self::$tags[$tag];
-        }
-    }
+	/**
+	 * 监听标签的行为
+	 * @param string $tag    标签名称
+	 * @param mixed  $params 传入参数
+	 * @param mixed  $extra  额外参数
+	 * @param bool   $once   只获取一个有效返回值
+	 * @return mixed
+	 */
+	public static function listen($tag, &$params = null, $extra = null, $once = false)
+	{
+		$results = [];
+		$tags = static::get($tag);
+		foreach ($tags as $key => $name) {
+			$results[$key] = self::exec($name, $tag, $params, $extra);
+			if (false === $results[$key]) {// 如果返回false 则中断行为执行
+				break;
+			} elseif (!is_null($results[$key]) && $once) {
+				break;
+			}
+		}
+		return $once ? end($results) : $results;
+	}
 
-    /**
-     * 监听标签的行为
-     * @param string $tag    标签名称
-     * @param mixed  $params 传入参数
-     * @param mixed  $extra  额外参数
-     * @param bool   $once   只获取一个有效返回值
-     * @return mixed
-     */
-    public static function listen($tag, &$params = null, $extra = null, $once = false)
-    {
-        $results = [];
-        if (isset(self::$tags[$tag])) {
-            foreach (self::$tags[$tag] as $name) {
+	/**
+	 * 执行某个行为
+	 * @param mixed     $class 要执行的行为
+	 * @param string    $tag 方法名（标签名）
+	 * @param Mixed     $params 传人的参数
+	 * @param mixed     $extra 额外参数
+	 * @return mixed
+	 */
+	public static function exec($class, $tag = '', &$params = null, $extra = null)
+	{
+		App::$debug && Debug::remark('behavior_start', 'time');
+		if (is_callable($class)) {
+			$result = call_user_func_array($class, [ & $params, $extra]);
+			$class = 'Closure';
+		} elseif (is_object($class)) {
+			$result = call_user_func_array([$class, $tag], [ & $params, $extra]);
+			$class = get_class($class);
+		} else {
+			$obj = new $class();
+			$result = ($tag && is_callable([$obj, $tag])) ? $obj->$tag($params, $extra) : $obj->run($params, $extra);
+		}
+		if (App::$debug) {
+			Debug::remark('behavior_end', 'time');
+			Log::record('[ BEHAVIOR ] Run ' . $class . ' @' . $tag . ' [ RunTime:' . Debug::getRangeTime('behavior_start', 'behavior_end') . 's ]', 'info');
+		}
+		return $result;
+	}
 
-                if (App::$debug) {
-                    Debug::remark('behavior_start', 'time');
-                }
-
-                $result = self::exec($name, $tag, $params, $extra);
-
-                if (!is_null($result) && $once) {
-                    return $result;
-                }
-
-                if (App::$debug) {
-                    Debug::remark('behavior_end', 'time');
-                    if ($name instanceof \Closure) {
-                        $name = 'Closure';
-                    } elseif (is_object($name)) {
-                        $name = get_class($name);
-                    }
-                    Log::record('[ BEHAVIOR ] Run ' . $name . ' @' . $tag . ' [ RunTime:' . Debug::getRangeTime('behavior_start', 'behavior_end') . 's ]', 'info');
-                }
-                if (false === $result) {
-                    // 如果返回false 则中断行为执行
-                    break;
-                }
-                $results[] = $result;
-            }
-        }
-        return $once ? null : $results;
-    }
-
-    /**
-     * 执行某个行为
-     * @param mixed     $class 要执行的行为
-     * @param string    $tag 方法名（标签名）
-     * @param Mixed     $params 传人的参数
-     * @param mixed     $extra 额外参数
-     * @return mixed
-     */
-    public static function exec($class, $tag = '', &$params = null,$extra=null)
-    {
-        if ($class instanceof \Closure) {
-            $result = call_user_func_array($class, [ & $params,$extra]);
-        } elseif (is_object($class)) {
-            $result = call_user_func_array([$class, $tag], [ & $params,$extra]);
-        } else {
-            $obj    = new $class();
-            $result = ($tag && is_callable([$obj, $tag])) ? $obj->$tag($params,$extra) : $obj->run($params,$extra);
-        }
-        return $result;
-    }
 }


### PR DESCRIPTION
1.改进get方法：防止数组索引未定义的异常；
2.改进listen方法：$once=true的时候有可能没有日志记录；返回最后一条执行结果；
3.改进import和add方法：_overlay配置由add方法处理；允许callable形式添加；
4.修改exec方法：日志记录由exec实现，减少两次判断。