### PR TITLE
完善分页url拼接,可以获取GET查询条件的参数

### DIFF
--- a/library/think/Paginator.php
+++ b/library/think/Paginator.php
@@ -121,7 +121,17 @@ abstract class Paginator
         if (!empty($parameters)) {
             $url .= '?' . urldecode(http_build_query($parameters, null, '&'));
         }
-        return $url . $this->buildFragment();
+        //获取url GET数据 拼接分页url 
+        $search_data=Request::instance()->request();
+        $last_url=$url . $this->buildFragment();
+        if(!empty($search_data)){
+            foreach ($search_data as $k=>$v){
+                if($k != $this->options['var_page']){
+                    $last_url.='&'.urldecode($k).'='.urldecode($v);
+                }
+            }
+        }
+        return $last_url;
     }
 
     /**


### PR DESCRIPTION
条件搜索通过GET查询时 搜索参数会显示在url上 但是原本分页拼接url时只拼接了分页参数,其他搜索条件并没有带上,所以原先的分页在展示第二页的时候会出错