### PR TITLE
解决Model类db()方法在$this->field=true时重复被调用的而引发的问题

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -158,7 +158,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
 
             if (!empty($this->field)) {
                 if (true === $this->field) {
-                    $type = $this->db()->getTableInfo('', 'type');
+                    $type = $query->getTableInfo('', 'type');
                 } else {
                     $type = [];
                     foreach ((array) $this->field as $key => $val) {


### PR DESCRIPTION
解决Model类db()方法在$this->field=true时重复被调用的而引发的问题