### PR TITLE
解决关联模型查询时关联条件丢失问题

### DIFF
--- a/library/think/model/Relation.php
+++ b/library/think/model/Relation.php
@@ -665,7 +665,9 @@ class Relation
     {
         if ($this->query) {
             switch ($this->type) {
+                case self::HAS_ONE:
                 case self::HAS_MANY:
+                case self::BELONGS_TO:
                     if (isset($this->where)) {
                         $this->query->where($this->where);
                     } elseif (isset($this->parent->{$this->localKey})) {


### PR DESCRIPTION
解决关联模型查询时关联条件丢失问题
像这种$model->relationMethod()->select()