### PR TITLE
更正field方法处理数据库函数的BUG

### DIFF
--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -733,7 +733,12 @@ class Query
             return $this;
         }
         if (is_string($field)) {
+             //正则表达式临时替换函数内的逗号为##
+            for($i=0;$i<5;$i++)
+                $field=preg_replace("/(\()([^\(]*?)(,)([^\),\(]*?)([\),])/",'$1$2##$4$5',$field);
             $field = array_map('trim', explode(',', $field));
+             //将临时替换的逗号转换回来
+            $field=preg_replace("/##/",',',$field);
         }
         if (true === $field) {
             // 获取全部字段


### PR DESCRIPTION
在当前filed方法处理传过来的$field字符串参数时，直接用了explode(',', $field))，导致用了isnull(name,0) as name这种包含逗号的函数时字段分割错误。
采用正则表达式替换的方式，将函数中的逗号临时替换，然后再用explode(',', $field))转化为数组，最后将数组中的临时符号转换回来。
此更改可以让field方法正确接收字符串形式的字段名，而不是强制要求用数组方式。

强制要求数据库函数一定要数组，实在是不方便，希望能够采纳。