### PR TITLE
增加Yaml配置驱动

### DIFF
--- a/library/think/config/driver/Yaml.php
+++ b/library/think/config/driver/Yaml.php
@@ -1,0 +1,21 @@
+<?php
+// +----------------------------------------------------------------------
+// | ThinkPHP [ WE CAN DO IT JUST THINK ]
+// +----------------------------------------------------------------------
+// | Copyright (c) 2006~2016 http://thinkphp.cn All rights reserved.
+// +----------------------------------------------------------------------
+// | Licensed ( http://www.apache.org/licenses/LICENSE-2.0 )
+// +----------------------------------------------------------------------
+// | Author: liu21st <liu21st@gmail.com>
+// +----------------------------------------------------------------------
+
+class Yaml{
+    public function parse($config)
+    {
+        if (is_file($config))
+        {
+             $config = yaml_parse_file($config);
+        }
+        return $config;
+    }
+}


### PR DESCRIPTION
Symfony框架中大多数的配置文件都是使用的yaml格式的文件，我大TP也不能落后，最近正好研究TP5，所以就动手添加了这么一个小驱动，希望自己能为TP5尽一点绵薄之力。