### PR TITLE
增加Yaml配置驱动

### DIFF
--- a/library/think/config/driver/Yaml.php
+++ b/library/think/config/driver/Yaml.php
@@ -1,0 +1,23 @@
+<?php
+// +----------------------------------------------------------------------
+// | ThinkPHP [ WE CAN DO IT JUST THINK ]
+// +----------------------------------------------------------------------
+// | Copyright (c) 2006~2016 http://thinkphp.cn All rights reserved.
+// +----------------------------------------------------------------------
+// | Licensed ( http://www.apache.org/licenses/LICENSE-2.0 )
+// +----------------------------------------------------------------------
+// | Author: liu21st <liu21st@gmail.com>
+// +----------------------------------------------------------------------
+
+namespace think\config\driver;
+
+class Yaml{
+    public function parse($config)
+    {
+        if (is_file($config))
+        {
+             $config = yaml_parse_file($config);
+        }
+        return $config;
+    }
+}


### PR DESCRIPTION
Symfony框架中大量使用yaml格式的文件作为配置文件，热爱TP的小伙伴们可能有需要这个东东的。