### PR TITLE
修复验证器规则无法获取多语言的问题

### DIFF
--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -377,7 +377,7 @@ class Validate
                     // 验证失败 返回错误信息
                     if (isset($msg[$i])) {
                         $message = $msg[$i];
-                        if (is_string($message) && strpos($message, '{%')) {
+                        if (is_string($message) && strpos($message, '{%') !== false) {
                             $message = Lang::get(substr($message, 2, -1));
                         }
                     } else {

--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -377,7 +377,7 @@ class Validate
                     // 验证失败 返回错误信息
                     if (isset($msg[$i])) {
                         $message = $msg[$i];
-                        if (is_string($message) && strpos($message, '{%') !== false) {
+                        if (is_string($message) && strpos($message, '{%') === 0) {
                             $message = Lang::get(substr($message, 2, -1));
                         }
                     } else {


### PR DESCRIPTION
修改条件为strpos($message, '{%') === 0