### PR TITLE
为Request类的几个方法完善注释

### DIFF
--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -1370,7 +1370,7 @@ class Request
      * 设置或者获取当前的模块名
      * @access public
      * @param string $module 模块名
-     * @return string|$this
+     * @return string|Request
      */
     public function module($module = null)
     {
@@ -1386,7 +1386,7 @@ class Request
      * 设置或者获取当前的控制器名
      * @access public
      * @param string $controller 控制器名
-     * @return string|$this
+     * @return string|Request
      */
     public function controller($controller = null)
     {
@@ -1402,7 +1402,7 @@ class Request
      * 设置或者获取当前的操作名
      * @access public
      * @param string $action 操作名
-     * @return string
+     * @return string|Request
      */
     public function action($action = null)
     {
@@ -1418,7 +1418,7 @@ class Request
      * 设置或者获取当前的语言
      * @access public
      * @param string $lang 语言名
-     * @return string
+     * @return string|Request
      */
     public function langset($lang = null)
     {


### PR DESCRIPTION
在phpstorm2016.2.1中，使用下列语句会提示警告： 

>Method __toString is not implemented for '\think\Request' less... (Ctrl+F1) 

>This inspection detects attempts to convert objects without __toString() method implementation to string, since PHP 5.2.0, it would cause E_RECOVERABLE_ERROR. "Check __toString exists for each expression type": if the option is on, the inspection will check all possible types of the expression and report if at least one ot them doesn't contain __toString() method implementation. 

```
$request = Request::instance();
echo "当前模块名称是" . $request->module();// 这句会被IDE提示警告
echo "当前控制器名称是" . $request->controller();// 这句会被IDE提示警告
echo "当前操作名称是" . $request->action();// 这句就不会
```

后来发现是注释引起的问题，注释中有`@return string|$this`。而action()方法却写成`@return string`。个人认为应该统一写成`@return string|Request` 比较合适。使用`$this`可能是想表示返回这个对象自身，但造成了一些麻烦。

而且，`langset()`和`action()`方法写法和另外两个一样有可能返回`$this`，却没有在注释中体现。

```
/**
     * 设置或者获取当前的模块名
     * @access public
     * @param string $module 模块名
     * @return string|$this
     */
    public function module($module = null)
```
学识短浅，仅供参考 。