### PR TITLE
修复Request->file()判断临时文件不严谨导致多文件上传失败的情况

### DIFF
--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -861,7 +861,7 @@ class Request
                     if ($file instanceof File) {
                         $array[$key] = $file;
                     } else {
-                        if (empty($file['tmp_name'])) {
+                        if (empty($file['tmp_name']) || !is_file($file['tmp_name'])) {
                             continue;
                         }
                         $array[$key] = (new File($file['tmp_name']))->setUploadInfo($file);


### PR DESCRIPTION
html文件
```
<form action="a.php" method="post" enctype="multipart/form-data">
    <input type="text" name="val" value="val"><br />
    <input type="file" name="logo"><br />
    <input type="file" name="video"><br />
    <button>按钮</button>
</form>
```

a.php
```
$file = $request->file('logo');var_dump($file);
            if (!empty($file)) {
                // 移动到框架应用根目录/public/uploads/ 目录下
                $info = $file->validate(['ext' => 'jpg,png'])->move(ROOT_PATH . 'public' . DS . 'uploads');

                if ($info) {
                    // $this->success('文件上传成功：' . $info->getRealPath());
                    $data['logo'] = str_replace('\\', '/', $info->getSaveName());
                    echo '<br />'.$info->getRealPath(). '<br />';
                } else {
                    // 上传失败获取错误信息
                    $this->error($file->getError());
                }
            }

            $file2 = $request->file('video');var_dump($file2);
            if (!empty($file2)) {
                // 移动到框架应用根目录/public/uploads/ 目录下
                $info2 = $file2->validate(['ext' => 'mp4'])->move(ROOT_PATH . 'public' . DS . 'uploads');

                if ($info2) {
                    // $this->success('文件上传成功：' . $info2->getRealPath());
                    $data['video'] = str_replace('\\', '/', $info2->getSaveName());
                    echo $info2->getRealPath();
                } else {
                    // 上传失败获取错误信息
                    $this->error($file2->getError());
                }
            }
```
这样的多文件上传代码会报错：
```
SplFileObject::__construct(/tmp/phpUlOxHg): failed to open stream: No such file or directory
```
但是在我的Windows本地环境下没有问题，linux上php5.6下出现上面的报错

通过调试，排查我发现了原因：原来linux下，文件上传后被“移走”了，临时文件就删除了，而Windows下还存在，所以本地成功，服务器上失败了。

其实这个问题很容易避免，这个问题是因为Request.php 中 file()方法判断临时文件不严谨导致的，从而将被移走的临时文件又传给了 (new File($file['tmp_name']))->setUploadInfo($file) 所以报错了。

补充：我没有使用官方img[]多文件上传的形式，因为项目中使用的是多字段，多文件上传的形式。

**其实可以总结下，文件上传分为：**
1. 单文件上传
 - 单一字段
2.  多文件上传
 - 多字段的形式多文件
 - 单一字段数组（img[]）的形式多文件上传
 - 组合多文件（上面几种情况的组合）

虽说在一个提交中按照一种形式上传文件比较规范，但是也不排除有的应用不按照规范，而框架的通用方法就要做好判断处理了。