### PR TITLE
增加 判断是否存在某个场景的验证配置

### DIFF
--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -217,6 +217,17 @@ class Validate
     }
 
     /**
+     * 判断是否存在某个验证场景
+     * @access public
+     * @param string $name 场景名
+     * @return bool
+     */
+    public function hasScene($name)
+    {
+        return isset($this->scene[$name]);
+    }
+
+    /**
      * 设置批量验证
      * @access public
      * @param bool $batch  是否批量验证


### PR DESCRIPTION
在做验证通用操作功能封装的时候，可以根据需要，是否启用场景验证