### PR TITLE
让Request支持json方式的POST

### DIFF
--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -686,7 +686,12 @@ class Request
     public function post($name = '', $default = null, $filter = '')
     {
         if (empty($this->post)) {
-            $this->post = $_POST;
+            $content = $this->input;
+            if (empty($_POST) && strpos($content, '":')) {
+                $this->post = json_decode($content, true);
+            } else {
+                $this->post = $_POST;
+            }
         }
         if (is_array($name)) {
             $this->param       = [];


### PR DESCRIPTION
目前RESTful API用json方式提交的很多
目前PUT/PATCH/DELETE方法均可以支持json，但POST方法不能，这不对等
其实更好的方法是判断header里content-type是否为application/json，但因为目前header属性采用的是懒加载，所以暂时沿用目前的字符串判断