### PR TITLE
error方法在ajax请求默认返回url为空

### DIFF
--- a/library/traits/controller/Jump.php
+++ b/library/traits/controller/Jump.php
@@ -80,8 +80,9 @@ trait Jump
             $code = $msg;
             $msg  = '';
         }
+        $isAjax = Request::instance()->isAjax();
         if (is_null($url)) {
-            $url = 'javascript:history.back(-1);';
+            $url = $isAjax ? '':'javascript:history.back(-1);';
         } elseif ('' !== $url) {
             $url = (strpos($url, '://') || 0 === strpos($url, '/')) ? $url : Url::build($url);
         }


### PR DESCRIPTION
error方法在Ajax请求，默认返回url为空，更合适，而且TP历史版本，返回url也是空