### PR TITLE
PHP7.1 session_set_handler返回值 只能接受string类型

### DIFF
--- a/library/think/session/driver/Redis.php
+++ b/library/think/session/driver/Redis.php
@@ -85,7 +85,7 @@ class Redis extends SessionHandler
      */
     public function read($sessID)
     {
-        return $this->handler->get($this->config['session_name'] . $sessID);
+        return $this->handler->get($this->config['session_name'] . $sessID) ?: '';
     }
 
     /**


### PR DESCRIPTION
PHP7.1 session_set_handler返回值 只能接受string类型