### PR TITLE
改进 writeTransform 方法，调整 array 类型使用习惯

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -376,12 +376,10 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 $value  = date($format, is_numeric($value) ? $value : strtotime($value));
                 break;
             case 'object':
-                if (is_object($value)) {
-                    $value = json_encode($value, JSON_FORCE_OBJECT);
-                }
+                is_scalar($value) || $value = json_encode($value, JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE);
                 break;
             case 'array':
-                $value = (array) $value;
+                $value = is_array($value) ? implode(',', $value) : strval($value);
             case 'json':
                 $option = !empty($param) ? (int) $param : JSON_UNESCAPED_UNICODE;
                 $value  = json_encode($value, $option);
@@ -475,7 +473,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 $value = json_decode($value, true);
                 break;
             case 'array':
-                $value = is_null($value) ? [] : json_decode($value, true);
+                $value = empty($value) ? [] : explode(',', $value);
                 break;
             case 'object':
                 $value = empty($value) ? new \stdClass() : json_decode($value);


### PR DESCRIPTION
1.改进 writeTransform 方法 object 类型，防止数组类型被忽略；
2.修正 writeTransform 方法 array 类型；
3.array 类型调整，改为,分割的字符串，比JSON省空间，适用于mysql的FIND_IN_SET()，但是仅支持单维索引数组