### PR TITLE
修复使用路由且fetch参数为空时无法加载默认视图文件的bug

### DIFF
--- a/library/think/App.php
+++ b/library/think/App.php
@@ -118,6 +118,12 @@ class App
             // 记录当前调度信息
             $request->dispatch($dispatch);
 
+            // 设置当前模块路径信息
+            if(empty(self::$modulePath)) {
+                $module = explode('/', isset($dispatch['controller']) ? $dispatch['controller'] : '');
+                self::$modulePath = isset($module[0]) ? APP_PATH . $module[0] . DS : null;
+            }
+
             // 记录路由和请求信息
             if (self::$debug) {
                 Log::record('[ ROUTE ] ' . var_export($dispatch, true), 'info');

--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -1388,7 +1388,11 @@ class Request
             $this->module = $module;
             return $this;
         } else {
-            return $this->module ?: '';
+            if(empty($this->module)) {
+                $module = explode('/', isset($this->dispatch['controller']) ? $this->dispatch['controller'] : '');
+                $this->module = isset($module[0]) ? $module[0] : '';
+            }
+            return $this->module;
         }
     }
 
@@ -1404,7 +1408,11 @@ class Request
             $this->controller = $controller;
             return $this;
         } else {
-            return $this->controller ?: '';
+            if(empty($this->controller)) {
+                $controller = explode('/', isset($this->dispatch['controller']) ? $this->dispatch['controller'] : '');
+                $this->controller = isset($controller[1]) ? $controller[1] : '';
+            }
+            return $this->controller;
         }
     }
 
@@ -1420,6 +1428,10 @@ class Request
             $this->action = $action;
             return $this;
         } else {
+            if(empty($this->action)){
+                $action = explode('/', isset($this->dispatch['controller']) ? $this->dispatch['controller'] : '');
+                $this->action = isset($action[2]) ? $action[2] : '';
+            }
             return $this->action ?: '';
         }
     }

--- a/library/think/view/driver/Think.php
+++ b/library/think/view/driver/Think.php
@@ -112,12 +112,12 @@ class Think
             // 跨模块调用
             list($module, $template) = explode('@', $template);
         }
+        $module = isset($module) ? $module : $request->module();
         if ($this->config['view_base']) {
             // 基础视图目录
-            $module = isset($module) ? $module : $request->module();
             $path   = $this->config['view_base'] . ($module ? $module . DS : '');
         } else {
-            $path = isset($module) ? APP_PATH . $module . DS . 'view' . DS : $this->config['view_path'];
+            $path = isset($this->config['view_path']) ? $this->config['view_path'] : APP_PATH . $module . DS . 'view' . DS;
         }
 
         $depr = $this->config['view_depr'];


### PR DESCRIPTION
路由配置文件为：'test/:id$' => 'index/index/index', 在index的action中调用$this->fetch()时不传递参数，访问地址为test.com/test/1.html时报找不到view/.html模板文件异常，访问test.com/index/index/index正常，现已修复，且所有情况已测试。