### PR TITLE
更新了saveAll方法中对于检测是否是更新的判断

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -811,7 +811,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 $auto = true;
             }
             foreach ($dataSet as $key => $data) {
-                if (!empty($auto) && isset($data[$pk])) {
+                if (!empty($auto) && isset($data[$pk]) && $data[$pk]>0) {
                     $result[$key] = self::update($data, [], $this->field);
                 } else {
                     $result[$key] = self::create($data, $this->field);


### PR DESCRIPTION
另加一个判断,只有当数据主键中的值大于0时才是更新操作,否则为添加操作.这样可以避免在添加多条数据时,如果数据中包含主键key但是值确是0时无法批量添加成功的问题.