### PR TITLE
可以允许自定义Output的driver，以适应命令行模式下调用其它命令行指令

### DIFF
--- a/library/think/Console.php
+++ b/library/think/Console.php
@@ -88,18 +88,19 @@ class Console
     }
 
     /**
-     * @param       $command
-     * @param array $parameters
+     * @param        $command
+     * @param array  $parameters
+     * @param string $driver
      * @return Output|Buffer
      */
-    public static function call($command, array $parameters = [])
+    public static function call($command, array $parameters = [], $driver = 'buffer')
     {
         $console = self::init(false);
 
         array_unshift($parameters, $command);
 
         $input  = new Input($parameters);
-        $output = new Output('buffer');
+        $output = new Output($driver);
 
         $console->setCatchExceptions(false);
         $console->find($command)->run($input, $output);


### PR DESCRIPTION
这样在命令行下，调用别的命令行，可以直接一行一行地输出日志，而不用等到buffer完，才输出