### PR TITLE
Update BelongsToMany.php

### DIFF
--- a/library/think/model/relation/BelongsToMany.php
+++ b/library/think/model/relation/BelongsToMany.php
@@ -308,7 +308,7 @@ class BelongsToMany extends Relation
      * @param bool              $relationDel 是否同时删除关联表数据
      * @return integer
      */
-    public function detach($data, $relationDel = false)
+    public function detach($data = null, $relationDel = false)
     {
         if (is_array($data)) {
             $id = $data;


### PR DESCRIPTION
给$data默认值null,应用场景:删除以关联外键为条件的中间表