### PR TITLE
默认关闭session的安全传输，此选项仅能在HTTPS下设置开启

### DIFF
--- a/convention.php
+++ b/convention.php
@@ -206,7 +206,7 @@ return [
         // 是否自动开启 SESSION
         'auto_start'     => true,
         'httponly'       => true,
-        'secure'         => true,
+        'secure'         => false,
     ],
 
     // +----------------------------------------------------------------------


### PR DESCRIPTION
HTTP下开启此配置后，浏览器不会发送前一个请求中服务器返回的PHPSESSID