### PR TITLE
配置参数名只分割为两部分

### DIFF
--- a/library/think/Config.php
+++ b/library/think/Config.php
@@ -87,7 +87,7 @@ class Config
             return isset(self::$config[$range][strtolower($name)]);
         } else {
             // 二维数组设置和获取支持
-            $name = explode('.', $name);
+            $name = explode('.', $name, 2);
             return isset(self::$config[$range][strtolower($name[0])][$name[1]]);
         }
     }
@@ -111,7 +111,7 @@ class Config
             return isset(self::$config[$range][$name]) ? self::$config[$range][$name] : null;
         } else {
             // 二维数组设置和获取支持
-            $name    = explode('.', $name);
+            $name    = explode('.', $name, 2);
             $name[0] = strtolower($name[0]);
             return isset(self::$config[$range][$name[0]][$name[1]]) ? self::$config[$range][$name[0]][$name[1]] : null;
         }
@@ -135,7 +135,7 @@ class Config
                 self::$config[$range][strtolower($name)] = $value;
             } else {
                 // 二维数组设置和获取支持
-                $name                                                 = explode('.', $name);
+                $name                                                 = explode('.', $name, 2);
                 self::$config[$range][strtolower($name[0])][$name[1]] = $value;
             }
             return;


### PR DESCRIPTION
分割后的$name只用到0和1键，因此explode加上limit参数
修改后还可以支持Config::set('abc.def.g')这种用法