### PR TITLE
添加一个session配置变量session_cookie_expire

### DIFF
--- a/library/think/Session.php
+++ b/library/think/Session.php
@@ -77,6 +77,9 @@ class Session
             ini_set('session.gc_maxlifetime', $config['expire']);
             ini_set('session.cookie_lifetime', $config['expire']);
         }
+        if(isset($config['session_cookie_expire'])){
+            ini_set('session.cookie_lifetime', $config['session_cookie_expire']);
+        }
         if (isset($config['secure'])) {
             ini_set('session.cookie_secure', $config['secure']);
         }


### PR DESCRIPTION
目前框架中的SessionID浏览器cookie有效期跟配置的session有效期相同，我在这里添加了一个配置变量session_cookie_expire用于设置sessionid的cookie有效期，实现自定义，如果不设置则跟session有效期相同