### PR TITLE
修复clear指令无法删除多级目录下文件的问题

### DIFF
--- a/library/think/console/command/Clear.php
+++ b/library/think/console/command/Clear.php
@@ -28,17 +28,27 @@ class Clear extends Command
 
     protected function execute(Input $input, Output $output)
     {
-        $path  = $input->getOption('path') ?: RUNTIME_PATH;
+        $path = $input->getOption('path') ?: RUNTIME_PATH;
+
+        if (is_dir($path)) {
+            $this->clearPath($path);
+        }
+
+        $output->writeln("<info>Clear Successed</info>");
+    }
+
+    protected function clearPath($path)
+    {
+        $path  = realpath($path) . DS;
         $files = scandir($path);
         if ($files) {
             foreach ($files as $file) {
                 if ('.' != $file && '..' != $file && is_dir($path . $file)) {
-                    array_map('unlink', glob($path . $file . '/*.*'));
+                    $this->clearPath($path . $file);
                 } elseif ('.gitignore' != $file && is_file($path . $file)) {
                     unlink($path . $file);
                 }
             }
         }
-        $output->writeln("<info>Clear Successed</info>");
     }
 }


### PR DESCRIPTION
之前的问题是log目录下日期目录下的日志文件无法清除。现在不论多少级都可以清除了