### PR TITLE
修复Session::prefix('xxx');设置当前作用域BUG

### DIFF
--- a/library/think/Session.php
+++ b/library/think/Session.php
@@ -56,8 +56,10 @@ class Session
             $isDoStart = true;
         }
 
-        if (isset($config['prefix'])) {
-            self::$prefix = $config['prefix'];
+        if (self::$prefix === '') {
+            if (isset($config['prefix'])) {
+                self::$prefix = $config['prefix'];
+            }
         }
         if (isset($config['var_session_id']) && isset($_REQUEST[$config['var_session_id']])) {
             session_id($_REQUEST[$config['var_session_id']]);

--- a/library/think/Session.php
+++ b/library/think/Session.php
@@ -56,7 +56,7 @@ class Session
             $isDoStart = true;
         }
 
-        if (isset($config['prefix']) && self::$prefix === '') {
+        if (isset($config['prefix']) && self::$prefix === '' && self::$prefix === null) {
             self::$prefix = $config['prefix'];
         }
         if (isset($config['var_session_id']) && isset($_REQUEST[$config['var_session_id']])) {

--- a/library/think/Session.php
+++ b/library/think/Session.php
@@ -56,7 +56,7 @@ class Session
             $isDoStart = true;
         }
 
-        if (isset($config['prefix']) && self::$prefix === '' && self::$prefix === null) {
+        if (isset($config['prefix']) && (self::$prefix === '' || self::$prefix === null)) {
             self::$prefix = $config['prefix'];
         }
         if (isset($config['var_session_id']) && isset($_REQUEST[$config['var_session_id']])) {

--- a/library/think/Session.php
+++ b/library/think/Session.php
@@ -56,10 +56,8 @@ class Session
             $isDoStart = true;
         }
 
-        if (self::$prefix === '') {
-            if (isset($config['prefix'])) {
-                self::$prefix = $config['prefix'];
-            }
+        if (isset($config['prefix']) && self::$prefix === '') {
+            self::$prefix = $config['prefix'];
         }
         if (isset($config['var_session_id']) && isset($_REQUEST[$config['var_session_id']])) {
             session_id($_REQUEST[$config['var_session_id']]);


### PR DESCRIPTION
Session在执行第一次set或者get等操作后才会执行一次Session初始化。
而在此之前调用Session::prefix('xxx');方法设置当前控制器的Session作用域会被之后的第一次set或者get等操作调用self::init();覆盖Session::prefix('xxx');设置。
我这里的改变使得可以在第一次session操作之前通过Session::prefix('xxx');有效设置作用域