### PR TITLE
sql异常时将出错的那条sql记录到日志中

### DIFF
--- a/library/think/exception/DbException.php
+++ b/library/think/exception/DbException.php
@@ -11,7 +11,9 @@
 
 namespace think\exception;
 
+use think\App;
 use think\Exception;
+use think\Log;
 
 /**
  * Database相关异常处理类
@@ -35,6 +37,8 @@ class DbException extends Exception
             'Error Message' => $message,
             'Error SQL'     => $sql,
         ]);
+
+        App::$debug && Log::record('[ SQL ] ' . $sql, 'sql');
 
         $this->setData('Database Config', $config);
     }


### PR DESCRIPTION
使用场景是，当用ajax或api请求时，无法马上知道哪句sql报错了。记录到日志的话，可以尽快定位出错的sql。