### PR TITLE
修复Request类下的变量获取BUG

### DIFF
--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -1003,7 +1003,7 @@ class Request
             $this->filterValue($data, $name, $filter);
         }
 
-        if (isset($type) && $data !== $default) {
+        if (isset($type) && $data !== $default && !is_array($data)) {
             // 强制类型转换
             $this->typeCast($data, $type);
         }


### PR DESCRIPTION
在Request类获取输入变量时，在param、get、post方法获取指定变量时，当输入参数以数组形式传入时，会导致input方法内调用强制类型转换，发生数组强制转字符串的错误，如当控制器中通过下面语句获取product变量:
``` php
Request::instance()->param('product');
```
此时前端通过Jquery的Ajax方法提交变量product，

``` javascript
var product = {
	name:"123",
	price:"7.00",
	unit:"袋",
	info:{
		pl:[12,12],
		bzq:5,
		bcfs:1
	}
};
$.ajax({
        url:'/newzcproduct',
        type:'POST',
        async:true,
        data:{
            product:product
        },
        timeout:5000,
        dataType:'json',
        beforeSend:function (xhr) {
            console.log(xhr);
            console.log(this.data);
        },
        success:function(data,textStatus,jqXHR){
            // console.log(data);
            // console.log(textStatus);
            // console.log(jqXHR);
        },
        error:function(xhr,textStatus){
            // console.log('错误');
            // console.log(xhr);
            // console.log(textStatus);
        },
        complete:function(){
            
        }
    });

```
可以得到Ajax发送出的参数字符串为：
```
product%5Bname%5D=123&product%5Bprice%5D=7.00&product%5Bunit%5D=%E8%A2%8B&product%5Binfo%5D%5Bpl%5D%5B%5D=12&product%5Binfo%5D%5Bpl%5D%5B%5D=12&product%5Binfo%5D%5Bbzq%5D=5&product%5Binfo%5D%5Bbcfs%5D=1
```
经过Url解码得到:
```
product[name]=123&product[price]=7.00&product[unit]=袋&product[info][pl][]=12&product[info][pl][]=12&product[info][bzq]=5&product[info][bcfs]=1
```
此时控制器接受后会抛出数组强制类型转换为字符串的错误

我在input方法内添加了一个判断$data是否为数组的条件，修复了这个错误
