### PR TITLE
命令行工具schema增加config参数，支持传入数据库连接配置

### DIFF
--- a/library/think/console/command/optimize/Schema.php
+++ b/library/think/console/command/optimize/Schema.php
@@ -25,6 +25,7 @@ class Schema extends Command
     protected function configure()
     {
         $this->setName('optimize:schema')
+            ->addOption('config', null, Option::VALUE_REQUIRED, 'db config .')
             ->addOption('db', null, Option::VALUE_REQUIRED, 'db name .')
             ->addOption('table', null, Option::VALUE_REQUIRED, 'table name .')
             ->addOption('module', null, Option::VALUE_REQUIRED, 'module name .')
@@ -35,6 +36,10 @@ class Schema extends Command
     {
         if (!is_dir(RUNTIME_PATH . 'schema')) {
             @mkdir(RUNTIME_PATH . 'schema', 0755, true);
+        }
+        $config = [];
+        if ($input->hasOption('config')) {
+            $config = $input->getOption('config');
         }
         if ($input->hasOption('module')) {
             $module = $input->getOption('module');
@@ -53,12 +58,12 @@ class Schema extends Command
         } elseif ($input->hasOption('table')) {
             $table = $input->getOption('table');
             if (!strpos($table, '.')) {
-                $dbName = Db::getConfig('database');
+                $dbName = Db::connect($config)->getConfig('database');
             }
             $tables[] = $table;
         } elseif ($input->hasOption('db')) {
             $dbName = $input->getOption('db');
-            $tables = Db::getTables($dbName);
+            $tables = Db::connect($config)->getTables($dbName);
         } elseif (!\think\Config::get('app_multi_module')) {
             $app  = App::$namespace;
             $list = scandir(APP_PATH . 'model');
@@ -72,11 +77,11 @@ class Schema extends Command
             $output->writeln('<info>Succeed!</info>');
             return;
         } else {
-            $tables = Db::getTables();
+            $tables = Db::connect($config)->getTables();
         }
 
         $db = isset($dbName) ? $dbName . '.' : '';
-        $this->buildDataBaseSchema($tables, $db);
+        $this->buildDataBaseSchema($tables, $db, $config);
 
         $output->writeln('<info>Succeed!</info>');
     }
@@ -94,16 +99,16 @@ class Schema extends Command
         }
     }
 
-    protected function buildDataBaseSchema($tables, $db)
+    protected function buildDataBaseSchema($tables, $db, $config)
     {
         if ('' == $db) {
-            $dbName = Db::getConfig('database') . '.';
+            $dbName = Db::connect($config)->getConfig('database') . '.';
         } else {
             $dbName = $db;
         }
         foreach ($tables as $table) {
             $content = '<?php ' . PHP_EOL . 'return ';
-            $info    = Db::getFields($db . $table);
+            $info    = Db::connect($config)->getFields($db . $table);
             $content .= var_export($info, true) . ';';
             file_put_contents(RUNTIME_PATH . 'schema' . DS . $dbName . $table . EXT, $content);
         }


### PR DESCRIPTION
多个数据库配置的情况下，仅用一个`--db`数据库名参数是无法满足的，所以这里加一个`--config`参数，也就是传入`Db::connect($config)` 方法的值。