### PR TITLE
修复optimize:autoload命令在EXTEND_PATH目录不存在的情况下，类库映射生成错误问题

### DIFF
--- a/library/think/console/command/optimize/Autoload.php
+++ b/library/think/console/command/optimize/Autoload.php
@@ -11,6 +11,7 @@
 namespace think\console\command\optimize;
 
 use think\App;
+use think\Config;
 use think\console\Command;
 use think\console\Input;
 use think\console\Output;
@@ -32,7 +33,7 @@ class Autoload extends Command
 /**
  * 类库映射
  */
- 
+
 return [
 
 EOF;
@@ -42,8 +43,13 @@ EOF;
             'think\\'              => LIB_PATH . 'think',
             'behavior\\'           => LIB_PATH . 'behavior',
             'traits\\'             => LIB_PATH . 'traits',
-            ''                     => realpath(rtrim(EXTEND_PATH))
+            ''                     => realpath(rtrim(EXTEND_PATH)),
         ];
+
+        $root_namespace = Config::get('root_namespace');
+        foreach ($root_namespace as $namespace => $dir) {
+            $namespacesToScan[$namespace . '\\'] = realpath($dir);
+        }
 
         krsort($namespacesToScan);
         $classMap = [];
@@ -84,7 +90,7 @@ EOF;
                 $this->output->writeln(
                     '<warning>Warning: Ambiguous class resolution, "' . $class . '"' .
                     ' was found in both "' . str_replace(["',\n"], [
-                        ''
+                        '',
                     ], $classMap[$class]) . '" and "' . $path . '", the first will be used.</warning>'
                 );
             }
@@ -99,6 +105,7 @@ EOF;
         $appPath    = $this->normalizePath(realpath(APP_PATH));
         $libPath    = $this->normalizePath(realpath(LIB_PATH));
         $extendPath = $this->normalizePath(realpath(EXTEND_PATH));
+        $rootPath   = $this->normalizePath(realpath(ROOT_PATH));
         $path       = $this->normalizePath($path);
 
         if (strpos($path, $libPath . '/') === 0) {
@@ -110,6 +117,9 @@ EOF;
         } elseif (strpos($path, $extendPath . '/') === 0) {
             $path    = substr($path, strlen($extendPath) + 1);
             $baseDir = 'EXTEND_PATH';
+        } elseif (strpos($path, $rootPath . '/') === 0) {
+            $path    = substr($path, strlen($rootPath) + 1);
+            $baseDir = 'ROOT_PATH';
         }
 
         if ($path !== false) {

--- a/library/think/console/command/optimize/Autoload.php
+++ b/library/think/console/command/optimize/Autoload.php
@@ -102,22 +102,22 @@ EOF;
     {
 
         $baseDir    = '';
-        $appPath    = $this->normalizePath(realpath(APP_PATH));
         $libPath    = $this->normalizePath(realpath(LIB_PATH));
+        $appPath    = $this->normalizePath(realpath(APP_PATH));
         $extendPath = $this->normalizePath(realpath(EXTEND_PATH));
         $rootPath   = $this->normalizePath(realpath(ROOT_PATH));
         $path       = $this->normalizePath($path);
 
-        if (strpos($path, $libPath . '/') === 0) {
+        if ($libPath !== null && strpos($path, $libPath . '/') === 0) {
             $path    = substr($path, strlen(LIB_PATH));
             $baseDir = 'LIB_PATH';
-        } elseif (strpos($path, $appPath . '/') === 0) {
+        } elseif ($appPath !== null && strpos($path, $appPath . '/') === 0) {
             $path    = substr($path, strlen($appPath) + 1);
             $baseDir = 'APP_PATH';
-        } elseif (strpos($path, $extendPath . '/') === 0) {
+        } elseif ($extendPath !== null && strpos($path, $extendPath . '/') === 0) {
             $path    = substr($path, strlen($extendPath) + 1);
             $baseDir = 'EXTEND_PATH';
-        } elseif (strpos($path, $rootPath . '/') === 0) {
+        } elseif ($rootPath !== null && strpos($path, $rootPath . '/') === 0) {
             $path    = substr($path, strlen($rootPath) + 1);
             $baseDir = 'ROOT_PATH';
         }
@@ -131,6 +131,9 @@ EOF;
 
     protected function normalizePath($path)
     {
+        if ($path === false) {
+            return null;
+        }
         $parts    = [];
         $path     = strtr($path, '\\', '/');
         $prefix   = '';


### PR DESCRIPTION
主要是因为 `realpath(EXTEND_PATH)` 函数得出结果为`false`后，后面没去作有效性判断。