### PR TITLE
增加是否分块上传检测图像文件逻辑

### DIFF
--- a/library/think/File.php
+++ b/library/think/File.php
@@ -196,7 +196,8 @@ class File extends SplFileObject
         }
 
         /* 检查图像文件 */
-        if (!$this->checkImg()) {
+        $is_chunk = isset($rule['is_chunk']) && $rule['is_chunk'] === true;
+        if (!$is_chunk && !$this->checkImg()) {
             $this->error = '非法图像文件！';
             return false;
         }


### PR DESCRIPTION
通过$validate进行配置当前是否分块上传
默认值为非分块上传，兼容旧的检测逻辑