### PR TITLE
修复使用insertAll()导致自递增主键值不连续问题

### DIFF
--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -752,7 +752,6 @@ abstract class Builder
             }
         }
         $fields = array_map([$this, 'parseKey'], array_keys(reset($dataSet)));
-        $sqldata = '';
         if($this->connection->getConfig('type') === 'mysql'){
             $sqldata = implode(',', $values);
         }else{

--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -745,7 +745,11 @@ abstract class Builder
                 }
             }
             $value    = array_values($data);
-            $values[] = '(' . implode(',', $value).')';
+            if($this->connection->getConfig('type') === 'mysql'){
+                $values[] = '(' . implode(',', $value).')';
+            }else{
+                $values[] = 'SELECT ' . implode(',', $value);
+            }
         }
         $fields = array_map([$this, 'parseKey'], array_keys(reset($dataSet)));
         $sqldata = '';

--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -27,7 +27,7 @@ abstract class Builder
     // SQL表达式
     protected $selectSql    = 'SELECT%DISTINCT% %FIELD% FROM %TABLE%%FORCE%%JOIN%%WHERE%%GROUP%%HAVING%%ORDER%%LIMIT% %UNION%%LOCK%%COMMENT%';
     protected $insertSql    = '%INSERT% INTO %TABLE% (%FIELD%) VALUES (%DATA%) %COMMENT%';
-    protected $insertAllSql = 'INSERT INTO %TABLE% (%FIELD%) VALUES %DATA% %COMMENT%';
+    protected $insertAllSql = 'INSERT INTO %TABLE% (%FIELD%) %DATA% %COMMENT%';
     protected $updateSql    = 'UPDATE %TABLE% SET %SET% %JOIN% %WHERE% %ORDER%%LIMIT% %LOCK%%COMMENT%';
     protected $deleteSql    = 'DELETE FROM %TABLE% %USING% %JOIN% %WHERE% %ORDER%%LIMIT% %LOCK%%COMMENT%';
 
@@ -748,12 +748,18 @@ abstract class Builder
             $values[] = '(' . implode(',', $value).')';
         }
         $fields = array_map([$this, 'parseKey'], array_keys(reset($dataSet)));
+        $sqldata = '';
+        if($this->connection->getConfig('type') === 'mysql'){
+            $sqldata = implode(',', $values);
+        }else{
+            $sqldata = implode(' UNION ALL ', $values);
+        }
         $sql    = str_replace(
             ['%TABLE%', '%FIELD%', '%DATA%', '%COMMENT%'],
             [
                 $this->parseTable($options['table'], $options),
                 implode(' , ', $fields),
-                implode(',', $values),
+                $sqldata,
                 $this->parseComment($options['comment']),
             ], $this->insertAllSql);
 

--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -27,7 +27,7 @@ abstract class Builder
     // SQL表达式
     protected $selectSql    = 'SELECT%DISTINCT% %FIELD% FROM %TABLE%%FORCE%%JOIN%%WHERE%%GROUP%%HAVING%%ORDER%%LIMIT% %UNION%%LOCK%%COMMENT%';
     protected $insertSql    = '%INSERT% INTO %TABLE% (%FIELD%) VALUES (%DATA%) %COMMENT%';
-    protected $insertAllSql = 'INSERT INTO %TABLE% (%FIELD%) %DATA% %COMMENT%';
+    protected $insertAllSql = 'INSERT INTO %TABLE% (%FIELD%) VALUES %DATA% %COMMENT%';
     protected $updateSql    = 'UPDATE %TABLE% SET %SET% %JOIN% %WHERE% %ORDER%%LIMIT% %LOCK%%COMMENT%';
     protected $deleteSql    = 'DELETE FROM %TABLE% %USING% %JOIN% %WHERE% %ORDER%%LIMIT% %LOCK%%COMMENT%';
 
@@ -745,7 +745,7 @@ abstract class Builder
                 }
             }
             $value    = array_values($data);
-            $values[] = 'SELECT ' . implode(',', $value);
+            $values[] = '(' . implode(',', $value).')';
         }
         $fields = array_map([$this, 'parseKey'], array_keys(reset($dataSet)));
         $sql    = str_replace(
@@ -753,7 +753,7 @@ abstract class Builder
             [
                 $this->parseTable($options['table'], $options),
                 implode(' , ', $fields),
-                implode(' UNION ALL ', $values),
+                implode(',', $values),
                 $this->parseComment($options['comment']),
             ], $this->insertAllSql);
 

--- a/library/think/db/builder/Mysql.php
+++ b/library/think/db/builder/Mysql.php
@@ -19,6 +19,7 @@ use think\db\Builder;
 class Mysql extends Builder
 {
     protected $updateSql = 'UPDATE %TABLE% %JOIN% SET %SET% %WHERE% %ORDER%%LIMIT% %LOCK%%COMMENT%';
+    protected $insertAllSql = 'INSERT INTO %TABLE% (%FIELD%) VALUES %DATA% %COMMENT%';
 
     /**
      * 字段和表名处理


### PR DESCRIPTION
在现有框架中使用insertAll插入多行数据，会导致自递增主键不连续的问题（Mysql）

如：

创建一个拥有自递增字段的表

```sql
CREATE TABLE productlabel
(
    id INT(10) unsigned PRIMARY KEY NOT NULL AUTO_INCREMENT,
    gid VARCHAR(255) NOT NULL,
    randomid VARCHAR(255) NOT NULL,
    datejl DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL
);
CREATE INDEX sy ON productlabel (gid, randomid);
```

在控制器中执行以下代码

```php
namespace app\production\controller;

use think\Db;

class Index {

    public function index(){

        $randid = array("234","123","562","552");

        $data = array();
        for($j = 0;$j < count($randid);$j++){
            $data[$j] = array(
                "gid" => "123",
                "randomid" => $randid[$j],
                "datejl" => "2017-03-29 00:00:00"
            );
        }
        for($i = 0;$i < 2;$i++){
            echo Db::table("productlabel")->insertAll($data);
            echo '<br/>';
        }

    }

}
```

共插入了8行记录，其中前4行记录id连续，而第5行跟第4行记录id不连续

此时查看表的AUTO_INCREMENT值已增加到了15

```mysql
MariaDB> SELECT `AUTO_INCREMENT`
FROM  INFORMATION_SCHEMA.TABLES
WHERE TABLE_SCHEMA = 'xgbw'
AND   TABLE_NAME   = 'productlabel';
+----------------+
| AUTO_INCREMENT |
+----------------+
| 15             |
+----------------+
1 行于数据集 (0.01 秒)
```

每一次执行insertAll都会导致数据插入完成之后AUTO_INCREMENT的值比正常情况下的值要增大(每次执行插入3行数据似乎没有这个问题)

我修改了生成的插入语句由多行insert语句修改为以下格式

```sql
INSERT INTO `productlabel` (`gid` , `randomid` , `datejl`) VALUES ('123','234','2017-03-29 00:00:00'),('123','123','2017-03-29 00:00:00'),('123','345','2017-03-29 00:00:00'),('123','521','2017-03-29 00:00:00')
```

就没有了这个自增字段不连续的问题

(更新)第一次提交的时候只考虑到了mysql多行插入，导致了其他数据库使用insertAll方法时会导致不兼容insert语句，现在更新后的代码在使用其他数据库的时候会使用原有的insert语句，在使用mysql的时候修复了我提交的这个错误