### PR TITLE
多语言功能的修改

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -354,22 +354,25 @@ if (!function_exists('cache')) {
     {
         if (is_array($options)) {
             // 缓存操作的同时初始化
-            Cache::connect($options);
+            $cache = Cache::connect($options);
         } elseif (is_array($name)) {
             // 缓存初始化
             return Cache::connect($name);
+        } else {
+            $cache = Cache::init();
         }
+
         if (is_null($name)) {
-            return Cache::clear($value);
+            return $cache->clear($value);
         } elseif ('' === $value) {
             // 获取缓存
-            return 0 === strpos($name, '?') ? Cache::has(substr($name, 1)) : Cache::get($name);
+            return 0 === strpos($name, '?') ? $cache->has(substr($name, 1)) : $cache->get($name);
         } elseif (is_null($value)) {
             // 删除缓存
-            return Cache::rm($name);
+            return $cache->rm($name);
         } elseif (0 === strpos($name, '?') && '' !== $value) {
             $expire = is_numeric($options) ? $options : null;
-            return Cache::remember(substr($name, 1), $value, $expire);
+            return $cache->remember(substr($name, 1), $value, $expire);
         } else {
             // 缓存数据
             if (is_array($options)) {
@@ -378,9 +381,9 @@ if (!function_exists('cache')) {
                 $expire = is_numeric($options) ? $options : null; //默认快捷缓存设置过期时间
             }
             if (is_null($tag)) {
-                return Cache::set($name, $value, $expire);
+                return $cache->set($name, $value, $expire);
             } else {
-                return Cache::tag($tag)->set($name, $value, $expire);
+                return $cache->tag($tag)->set($name, $value, $expire);
             }
         }
     }

--- a/library/think/App.php
+++ b/library/think/App.php
@@ -85,14 +85,14 @@ class App
 
             $request->filter($config['default_filter']);
 
+            // 默认语言
+            Lang::range($config['default_lang']);
             if ($config['lang_switch_on']) {
                 // 开启多语言机制 检测当前语言
                 Lang::detect();
-            } else {
-                // 读取默认语言
-                Lang::range($config['default_lang']);
             }
             $request->langset(Lang::range());
+
             // 加载系统语言包
             Lang::load([
                 THINK_PATH . 'lang' . DS . $request->langset() . EXT,

--- a/library/think/Cache.php
+++ b/library/think/Cache.php
@@ -51,28 +51,29 @@ class Cache
                 self::$instance[$name] = new $class($options);
             }
         }
-        self::$handler = self::$instance[$name];
-        return self::$handler;
+        return self::$instance[$name];
     }
 
     /**
      * 自动初始化缓存
      * @access public
      * @param array         $options  配置数组
-     * @return void
+     * @return Driver
      */
     public static function init(array $options = [])
     {
         if (is_null(self::$handler)) {
             // 自动初始化缓存
             if (!empty($options)) {
-                self::connect($options);
+                $connect = self::connect($options);
             } elseif ('complex' == Config::get('cache.type')) {
-                self::connect(Config::get('cache.default'));
+                $connect = self::connect(Config::get('cache.default'));
             } else {
-                self::connect(Config::get('cache'));
+                $connect = self::connect(Config::get('cache'));
             }
+            self::$handler = $connect;
         }
+        return self::$handler;
     }
 
     /**
@@ -84,9 +85,9 @@ class Cache
     public static function store($name = '')
     {
         if ('' !== $name && 'complex' == Config::get('cache.type')) {
-            self::connect(Config::get('cache.' . $name), strtolower($name));
+            return self::connect(Config::get('cache.' . $name), strtolower($name));
         }
-        return self::$handler;
+        return self::init();
     }
 
     /**
@@ -97,9 +98,8 @@ class Cache
      */
     public static function has($name)
     {
-        self::init();
         self::$readTimes++;
-        return self::$handler->has($name);
+        return self::init()->has($name);
     }
 
     /**
@@ -111,9 +111,8 @@ class Cache
      */
     public static function get($name, $default = false)
     {
-        self::init();
         self::$readTimes++;
-        return self::$handler->get($name, $default);
+        return self::init()->get($name, $default);
     }
 
     /**
@@ -126,9 +125,8 @@ class Cache
      */
     public static function set($name, $value, $expire = null)
     {
-        self::init();
         self::$writeTimes++;
-        return self::$handler->set($name, $value, $expire);
+        return self::init()->set($name, $value, $expire);
     }
 
     /**
@@ -140,9 +138,8 @@ class Cache
      */
     public static function inc($name, $step = 1)
     {
-        self::init();
         self::$writeTimes++;
-        return self::$handler->inc($name, $step);
+        return self::init()->inc($name, $step);
     }
 
     /**
@@ -154,9 +151,8 @@ class Cache
      */
     public static function dec($name, $step = 1)
     {
-        self::init();
         self::$writeTimes++;
-        return self::$handler->dec($name, $step);
+        return self::init()->dec($name, $step);
     }
 
     /**
@@ -167,9 +163,8 @@ class Cache
      */
     public static function rm($name)
     {
-        self::init();
         self::$writeTimes++;
-        return self::$handler->rm($name);
+        return self::init()->rm($name);
     }
 
     /**
@@ -180,9 +175,8 @@ class Cache
      */
     public static function clear($tag = null)
     {
-        self::init();
         self::$writeTimes++;
-        return self::$handler->clear($tag);
+        return self::init()->clear($tag);
     }
 
     /**
@@ -193,10 +187,9 @@ class Cache
      */
     public static function pull($name)
     {
-        self::init();
         self::$readTimes++;
         self::$writeTimes++;
-        return self::$handler->pull($name);
+        return self::init()->pull($name);
     }
 
     /**
@@ -209,9 +202,8 @@ class Cache
      */
     public static function remember($name, $value, $expire = null)
     {
-        self::init();
         self::$readTimes++;
-        return self::$handler->remember($name, $value, $expire);
+        return self::init()->remember($name, $value, $expire);
     }
 
     /**
@@ -224,8 +216,7 @@ class Cache
      */
     public static function tag($name, $keys = null, $overlay = false)
     {
-        self::init();
-        return self::$handler->tag($name, $keys, $overlay);
+        return self::init()->tag($name, $keys, $overlay);
     }
 
 }

--- a/library/think/Cookie.php
+++ b/library/think/Cookie.php
@@ -135,22 +135,35 @@ class Cookie
      * @param string|null   $prefix cookie前缀
      * @return mixed
      */
-    public static function get($name, $prefix = null)
+    public static function get($name = '', $prefix = null)
     {
         !isset(self::$init) && self::init();
         $prefix = !is_null($prefix) ? $prefix : self::$config['prefix'];
-        $name   = $prefix . $name;
-        if (isset($_COOKIE[$name])) {
-            $value = $_COOKIE[$name];
+        $key    = $prefix . $name;
+
+        if ('' == $name) {
+            // 获取全部
+            if ($prefix) {
+                $value = [];
+                foreach ($_COOKIE as $k => $val) {
+                    if (0 === strpos($k, $prefix)) {
+                        $value[$k] = $val;
+                    }
+                }
+            } else {
+                $value = $_COOKIE;
+            }
+        } elseif (isset($_COOKIE[$key])) {
+            $value = $_COOKIE[$key];
             if (0 === strpos($value, 'think:')) {
                 $value = substr($value, 6);
                 $value = json_decode($value, true);
                 array_walk_recursive($value, 'self::jsonFormatProtect', 'decode');
             }
-            return $value;
         } else {
-            return;
+            $value = null;
         }
+        return $value;
     }
 
     /**

--- a/library/think/Db.php
+++ b/library/think/Db.php
@@ -36,7 +36,7 @@ use think\db\Query;
  * @method integer update(array $data) static 更新记录
  * @method integer delete(mixed $data = null) static 删除记录
  * @method boolean chunk(integer $count, callable $callback, string $column = null) static 分块获取数据
- * @method mixed query(string $sql, array $bind = [], boolean $fetch = false, boolean $master = false, mixed $class = null) static SQL查询
+ * @method mixed query(string $sql, array $bind = [], boolean $master = false, bool $pdo = false) static SQL查询
  * @method integer execute(string $sql, array $bind = [], boolean $fetch = false, boolean $getLastInsID = false, string $sequence = null) static SQL执行
  * @method Paginator paginate(integer $listRows = 15, mixed $simple = null, array $config = []) static 分页查询
  * @method mixed transaction(callable $callback) static 执行数据库事务
@@ -44,6 +44,8 @@ use think\db\Query;
  * @method void commit() static 用于非自动提交状态下面的查询提交
  * @method void rollback() static 事务回滚
  * @method boolean batchQuery(array $sqlArray) static 批处理执行SQL语句
+ * @method string quote(string $str) static SQL指令安全过滤
+ * @method string getLastInsID($sequence = null) static 获取最近插入的ID
  */
 class Db
 {

--- a/library/think/Lang.php
+++ b/library/think/Lang.php
@@ -25,6 +25,8 @@ class Lang
     protected static $langCookieExpire = 3600;
     // 允许语言列表
     protected static $allowLangList = [];
+    //Accept-Language转义为对应的语言包 系统默认设置
+    private static $acceptLanguage = ['zh-hans-cn'=>'zh-cn'];
 
     // 设定当前的语言
     public static function range($range = '')
@@ -34,6 +36,7 @@ class Lang
         } else {
             self::$range = $range;
         }
+        return self::$range;
     }
 
     /**
@@ -93,7 +96,6 @@ class Lang
     /**
      * 获取语言定义(不区分大小写)
      * @param string|null   $name 语言变量
-     * @param array         $vars 变量替换
      * @param string        $range 语言作用域
      * @return mixed
      */
@@ -152,25 +154,25 @@ class Lang
     {
         // 自动侦测设置获取语言选择
         $langSet = '';
+
         if (isset($_GET[self::$langDetectVar])) {
             // url中设置了语言变量
             $langSet = strtolower($_GET[self::$langDetectVar]);
-            Cookie::set(self::$langCookieVar, $langSet, self::$langCookieExpire);
-        } elseif (Cookie::get(self::$langCookieVar)) {
-            // 获取上次用户的选择
-            $langSet = strtolower(Cookie::get(self::$langCookieVar));
-        } elseif (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+        }
+        elseif (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
             // 自动侦测浏览器语言
             preg_match('/^([a-z\d\-]+)/i', $_SERVER['HTTP_ACCEPT_LANGUAGE'], $matches);
             $langSet = strtolower($matches[1]);
-            Cookie::set(self::$langCookieVar, $langSet, self::$langCookieExpire);
+            $header_accept_lang_config = Config::get('header_accept_lang');
+            if(isset($header_accept_lang_config[$langSet])){
+                $langSet =$header_accept_lang_config[$langSet];
+            }elseif(isset(self::$acceptLanguage[$langSet])){
+                $langSet =self::$acceptLanguage[$langSet];
+            }
         }
         if (empty(self::$allowLangList) || in_array($langSet, self::$allowLangList)) {
             // 合法的语言
             self::$range = $langSet ?: self::$range;
-        }
-        if ('zh-hans-cn' == self::$range) {
-            self::$range = 'zh-cn';
         }
         return self::$range;
     }

--- a/library/think/Log.php
+++ b/library/think/Log.php
@@ -84,7 +84,7 @@ class Log
     public static function record($msg, $type = 'log')
     {
         self::$log[$type][] = $msg;
-        if (IS_CLI && count(self::$log[$type]) > 100) {
+        if (IS_CLI) {
             // 命令行下面日志写入改进
             self::save();
         }
@@ -101,7 +101,7 @@ class Log
 
     /**
      * 当前日志记录的授权key
-     * @param string  $key  授权key
+     * @param string $key 授权key
      * @return void
      */
     public static function key($key)
@@ -111,7 +111,7 @@ class Log
 
     /**
      * 检查日志写入权限
-     * @param array  $config  当前日志配置参数
+     * @param array $config 当前日志配置参数
      * @return bool
      */
     public static function check($config)
@@ -166,13 +166,14 @@ class Log
 
     /**
      * 实时写入日志信息 并支持行为
-     * @param mixed  $msg  调试信息
-     * @param string $type 信息类型
+     * @param mixed  $msg   调试信息
+     * @param string $type  信息类型
      * @param bool   $force 是否强制写入
      * @return bool
      */
     public static function write($msg, $type = 'log', $force = false)
     {
+        $log = self::$log;
         // 封装日志信息
         if (true === $force || empty(self::$config['level'])) {
             $log[$type][] = $msg;
@@ -188,7 +189,11 @@ class Log
             self::init(Config::get('log'));
         }
         // 写入日志
-        return self::$driver->save($log, false);
+        $result = self::$driver->save($log);
+        if ($result) {
+            self::$log = [];
+        }
+        return $result;
     }
 
     /**

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -779,6 +779,22 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         return false;
     }
 
+    protected function autoWriteUpdateTime()
+    {
+        // 自动写入更新时间
+        if ($this->autoWriteTimestamp && $this->updateTime && (empty($this->change) || !in_array($this->updateTime, $this->change))) {
+            $this->setAttr($this->updateTime, null);
+        }
+    }
+
+    protected function autoWriteCreateTime()
+    {
+        // 自动写入创建时间
+        if ($this->autoWriteTimestamp && $this->createTime && (empty($this->change) || !in_array($this->createTime, $this->change))) {
+            $this->setAttr($this->createTime, null);
+        }
+    }
+
     /**
      * 保存当前数据对象
      * @access public
@@ -839,11 +855,6 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         // 数据自动完成
         $this->autoCompleteData($this->auto);
 
-        // 自动写入更新时间
-        if ($this->autoWriteTimestamp && $this->updateTime && (empty($this->change) || !in_array($this->updateTime, $this->change))) {
-            $this->setAttr($this->updateTime, null);
-        }
-
         // 事件回调
         if (false === $this->trigger('before_write', $this)) {
             return false;
@@ -873,6 +884,12 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                         unset($data[$field]);
                     }
                 }
+            }
+
+            if (!empty($data)) {
+                $this->autoWriteUpdateTime();
+            } else {
+                return 0;
             }
 
             if (empty($where) && !empty($this->updateWhere)) {
@@ -922,10 +939,8 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
             // 自动写入
             $this->autoCompleteData($this->insert);
 
-            // 自动写入创建时间
-            if ($this->autoWriteTimestamp && $this->createTime && (empty($this->change) || !in_array($this->createTime, $this->change))) {
-                $this->setAttr($this->createTime, null);
-            }
+            $this->autoWriteCreateTime();
+            $this->autoWriteUpdateTime();
 
             if (false === $this->trigger('before_insert', $this)) {
                 return false;

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -1484,7 +1484,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         }
         $model     = new static();
         $params    = func_get_args();
-        $params[0] = $model->db();
+        $params[0] = $model->getQuery();
         if ($name instanceof \Closure) {
             call_user_func_array($name, $params);
         } elseif (is_string($name)) {
@@ -1509,8 +1509,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
      */
     public static function useGlobalScope($use)
     {
-        $model      = new static();
-        static::$db = $model->db($use);
+        $model = new static();
         return $model;
     }
 
@@ -1886,7 +1885,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     public static function __callStatic($method, $args)
     {
         $model = new static();
-        $query = $model->db();
+        $query = $model->db(true, false);
 
         if (method_exists($model, 'scope' . $method)) {
             // 动态调用命名范围

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -380,7 +380,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 if (empty($param)) {
                     $value = (float) $value;
                 } else {
-                    $value = (float) number_format($value, $param);
+                    $value = (float) number_format($value, $param, '.', '');
                 }
                 break;
             case 'boolean':
@@ -488,7 +488,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 if (empty($param)) {
                     $value = (float) $value;
                 } else {
-                    $value = (float) number_format($value, $param);
+                    $value = (float) number_format($value, $param, '.', '');
                 }
                 break;
             case 'boolean':

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -367,6 +367,10 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
      */
     protected function writeTransform($value, $type)
     {
+        if (is_null($value)) {
+            return null;
+        }
+
         if (is_array($type)) {
             list($type, $param) = $type;
         } elseif (strpos($type, ':')) {
@@ -475,6 +479,10 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
      */
     protected function readTransform($value, $type)
     {
+        if (is_null($value)) {
+            return null;
+        }
+
         if (is_array($type)) {
             list($type, $param) = $type;
         } elseif (strpos($type, ':')) {

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -1747,9 +1747,11 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
      */
     public function morphTo($morph = null, $alias = [])
     {
+        $trace    = debug_backtrace(false, 2);
+        $relation = Loader::parseName($trace[1]['function']);
+
         if (is_null($morph)) {
-            $trace = debug_backtrace(false, 2);
-            $morph = Loader::parseName($trace[1]['function']);
+            $morph = $relation;
         }
         // 记录当前关联信息
         if (is_array($morph)) {
@@ -1758,7 +1760,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
             $morphType  = $morph . '_type';
             $foreignKey = $morph . '_id';
         }
-        return new MorphTo($this, $morphType, $foreignKey, $alias);
+        return new MorphTo($this, $morphType, $foreignKey, $alias, $relation);
     }
 
     public function __call($method, $args)

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -870,13 +870,12 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 }
             }
 
-            if (!empty($data)) {
-                if ($this->autoWriteTimestamp && $this->updateTime && !isset($data[$this->updateTime])) {
-                    // 自动写入更新时间
-                    $data[$this->updateTime] = $this->autoWriteTimestamp($this->updateTime);
-                }
-            } else {
+            if (empty($data) || (count($data) == 1 && is_string($pk) && isset($data[$pk]))) {
+                // 没有更新
                 return 0;
+            } elseif ($this->autoWriteTimestamp && $this->updateTime && !isset($data[$this->updateTime])) {
+                // 自动写入更新时间
+                $data[$this->updateTime] = $this->autoWriteTimestamp($this->updateTime);
             }
 
             if (empty($where) && !empty($this->updateWhere)) {

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -283,7 +283,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
             // 检测修改器
             $method = 'set' . Loader::parseName($name, 1) . 'Attr';
             if (method_exists($this, $method)) {
-                $value = $this->$method($value, array_merge($data, $this->data));
+                $value = $this->$method($value, $data);
             } elseif (isset($this->type[$name])) {
                 // 类型转换
                 $value = $this->writeTransform($value, $this->type[$name]);

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -870,9 +870,11 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 }
             }
 
-            if (!empty($data) && $this->autoWriteTimestamp && $this->updateTime && !isset($data[$this->updateTime])) {
-                // 自动写入更新时间
-                $data[$this->updateTime] = $this->autoWriteTimestamp($this->updateTime);
+            if (!empty($data)) {
+                if ($this->autoWriteTimestamp && $this->updateTime && !isset($data[$this->updateTime])) {
+                    // 自动写入更新时间
+                    $data[$this->updateTime] = $this->autoWriteTimestamp($this->updateTime);
+                }
             } else {
                 return 0;
             }

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -1294,11 +1294,15 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
      * @param mixed        $data  主键值或者查询条件（闭包）
      * @param array|string $with  关联预查询
      * @param bool         $cache 是否缓存
-     * @return static
+     * @return static|null
      * @throws exception\DbException
      */
-    public static function get($data = null, $with = [], $cache = false)
+    public static function get($data, $with = [], $cache = false)
     {
+        if (is_null($data)) {
+            return null;
+        }
+
         if (true === $with || is_int($with)) {
             $cache = $with;
             $with  = [];

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -1651,7 +1651,9 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         $model      = $this->parseModel($model);
         $foreignKey = $foreignKey ?: $this->getForeignKey($model);
         $localKey   = $localKey ?: (new $model)->getPk();
-        return new BelongsTo($this, $model, $foreignKey, $localKey, $joinType);
+        $trace      = debug_backtrace(false, 2);
+        $relation   = Loader::parseName($trace[1]['function']);
+        return new BelongsTo($this, $model, $foreignKey, $localKey, $joinType, $relation);
     }
 
     /**

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -1300,7 +1300,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     public static function get($data, $with = [], $cache = false)
     {
         if (is_null($data)) {
-            return null;
+            return;
         }
 
         if (true === $with || is_int($with)) {

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -779,22 +779,6 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         return false;
     }
 
-    protected function autoWriteUpdateTime(&$data)
-    {
-        // 自动写入更新时间
-        if ($this->autoWriteTimestamp && $this->updateTime && (empty($this->change) || !in_array($this->updateTime, $this->change))) {
-            $data[$this->updateTime] = $this->autoWriteTimestamp($this->updateTime);
-        }
-    }
-
-    protected function autoWriteCreateTime(&$data)
-    {
-        // 自动写入创建时间
-        if ($this->autoWriteTimestamp && $this->createTime && (empty($this->change) || !in_array($this->createTime, $this->change))) {
-            $data[$this->createTime] = $this->autoWriteTimestamp($this->createTime);
-        }
-    }
-
     /**
      * 保存当前数据对象
      * @access public
@@ -886,9 +870,9 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 }
             }
 
-            if (!empty($data)) {
+            if (!empty($data) && $this->autoWriteTimestamp && $this->updateTime && !isset($data[$this->updateTime])) {
                 // 自动写入更新时间
-                $this->autoWriteUpdateTime($data);
+                $data[$this->updateTime] = $this->autoWriteTimestamp($this->updateTime);
             } else {
                 return 0;
             }
@@ -939,10 +923,15 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         } else {
             // 自动写入
             $this->autoCompleteData($this->insert);
-            // 自动写入创建时间
-            $this->autoWriteCreateTime($this->data);
-            // 自动写入更新时间
-            $this->autoWriteUpdateTime($this->data);
+            // 自动写入创建时间和更新时间
+            if ($this->autoWriteTimestamp) {
+                if ($this->createTime && !isset($this->data[$this->createTime])) {
+                    $this->data[$this->createTime] = $this->autoWriteTimestamp($this->createTime);
+                }
+                if ($this->updateTime && !isset($this->data[$this->updateTime])) {
+                    $this->data[$this->updateTime] = $this->autoWriteTimestamp($this->updateTime);
+                }
+            }
 
             if (false === $this->trigger('before_insert', $this)) {
                 return false;

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -1475,16 +1475,17 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
      * @access public
      * @param string|array|\Closure $name 命名范围名称 逗号分隔
      * @internal  mixed                 ...$params 参数调用
-     * @return Model|Query
+     * @return Query
      */
     public static function scope($name)
     {
         if ($name instanceof Query) {
             return $name;
         }
-        $model     = new static();
-        $params    = func_get_args();
-        $params[0] = $model->getQuery();
+        $model  = new static();
+        $query  = $model->db();
+        $params = func_get_args();
+        array_unshift($params, $query);
         if ($name instanceof \Closure) {
             call_user_func_array($name, $params);
         } elseif (is_string($name)) {
@@ -1498,7 +1499,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 }
             }
         }
-        return $model;
+        return $query;
     }
 
     /**
@@ -1885,7 +1886,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     public static function __callStatic($method, $args)
     {
         $model = new static();
-        $query = $model->db(true, false);
+        $query = $model->db();
 
         if (method_exists($model, 'scope' . $method)) {
             // 动态调用命名范围

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -369,7 +369,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     protected function writeTransform($value, $type)
     {
         if (is_null($value)) {
-            return null;
+            return;
         }
 
         if (is_array($type)) {
@@ -481,7 +481,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     protected function readTransform($value, $type)
     {
         if (is_null($value)) {
-            return null;
+            return;
         }
 
         if (is_array($type)) {

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -22,6 +22,7 @@ use think\model\relation\HasMany;
 use think\model\relation\HasManyThrough;
 use think\model\relation\HasOne;
 use think\model\relation\MorphMany;
+use think\model\relation\MorphOne;
 use think\model\relation\MorphTo;
 
 /**
@@ -1738,6 +1739,32 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
             $foreignKey = $morph . '_id';
         }
         return new MorphMany($this, $model, $foreignKey, $morphType, $type);
+    }
+
+    /**
+     * MORPH  One 关联定义
+     * @access public
+     * @param string       $model 模型名
+     * @param string|array $morph 多态字段信息
+     * @param string       $type  多态类型
+     * @return MorphOne
+     */
+    public function morphOne($model, $morph = null, $type = '')
+    {
+        // 记录当前关联信息
+        $model = $this->parseModel($model);
+        if (is_null($morph)) {
+            $trace = debug_backtrace(false, 2);
+            $morph = Loader::parseName($trace[1]['function']);
+        }
+        $type = $type ?: Loader::parseName($this->name);
+        if (is_array($morph)) {
+            list($morphType, $foreignKey) = $morph;
+        } else {
+            $morphType  = $morph . '_type';
+            $foreignKey = $morph . '_id';
+        }
+        return new MorphOne($this, $model, $foreignKey, $morphType, $type);
     }
 
     /**

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -779,19 +779,19 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         return false;
     }
 
-    protected function autoWriteUpdateTime()
+    protected function autoWriteUpdateTime(&$data)
     {
         // 自动写入更新时间
         if ($this->autoWriteTimestamp && $this->updateTime && (empty($this->change) || !in_array($this->updateTime, $this->change))) {
-            $this->setAttr($this->updateTime, null);
+            $data[$this->updateTime] = $this->autoWriteTimestamp($this->updateTime);
         }
     }
 
-    protected function autoWriteCreateTime()
+    protected function autoWriteCreateTime(&$data)
     {
         // 自动写入创建时间
         if ($this->autoWriteTimestamp && $this->createTime && (empty($this->change) || !in_array($this->createTime, $this->change))) {
-            $this->setAttr($this->createTime, null);
+            $data[$this->createTime] = $this->autoWriteTimestamp($this->createTime);
         }
     }
 
@@ -887,7 +887,8 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
             }
 
             if (!empty($data)) {
-                $this->autoWriteUpdateTime();
+                // 自动写入更新时间
+                $this->autoWriteUpdateTime($data);
             } else {
                 return 0;
             }
@@ -938,9 +939,10 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         } else {
             // 自动写入
             $this->autoCompleteData($this->insert);
-
-            $this->autoWriteCreateTime();
-            $this->autoWriteUpdateTime();
+            // 自动写入创建时间
+            $this->autoWriteCreateTime($this->data);
+            // 自动写入更新时间
+            $this->autoWriteUpdateTime($this->data);
 
             if (false === $this->trigger('before_insert', $this)) {
                 return false;

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -175,7 +175,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         // 设置当前模型 确保查询返回模型对象
         $queryClass = $this->query ?: $con->getConfig('query');
         $query      = new $queryClass($con, $this->class);
-        $con->setQuery($query);
+        $con->setQuery($query, $this->class);
 
         // 设置当前数据表和模型名
         if (!empty($this->table)) {

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -917,10 +917,9 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 }
             }
 
-            // 清空change
-            $this->change = [];
             // 更新回调
             $this->trigger('after_update', $this);
+
         } else {
             // 自动写入
             $this->autoCompleteData($this->insert);
@@ -958,13 +957,15 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
 
             // 标记为更新
             $this->isUpdate = true;
-            // 清空change
-            $this->change = [];
+
             // 新增回调
             $this->trigger('after_insert', $this);
         }
         // 写入回调
         $this->trigger('after_write', $this);
+
+        // 清空change
+        $this->change = [];
 
         return $result;
     }

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -138,16 +138,16 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
 
         if (is_null($this->autoWriteTimestamp)) {
             // 自动写入时间戳
-            $this->autoWriteTimestamp = $this->db(false)->getConfig('auto_timestamp');
+            $this->autoWriteTimestamp = $this->getQuery()->getConfig('auto_timestamp');
         }
 
         if (is_null($this->dateFormat)) {
             // 设置时间戳格式
-            $this->dateFormat = $this->db(false)->getConfig('datetime_format');
+            $this->dateFormat = $this->getQuery()->getConfig('datetime_format');
         }
 
         if (is_null($this->resultSetType)) {
-            $this->resultSetType = $this->db(false)->getConfig('resultset_type');
+            $this->resultSetType = $this->getQuery()->getConfig('resultset_type');
         }
         // 执行初始化操作
         $this->initialize();
@@ -839,10 +839,10 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     public function getPk($name = '')
     {
         if (!empty($name)) {
-            $table = $this->db(false)->getTable($name);
-            return $this->db(false)->getPk($table);
+            $table = $this->getQuery()->getTable($name);
+            return $this->getQuery()->getPk($table);
         } elseif (empty($this->pk)) {
-            $this->pk = $this->db(false)->getPk();
+            $this->pk = $this->getQuery()->getPk();
         }
         return $this->pk;
     }
@@ -912,7 +912,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         // 检测字段
         if (!empty($this->field)) {
             if (true === $this->field) {
-                $this->field = $this->db(false)->getTableInfo('', 'fields');
+                $this->field = $this->getQuery()->getTableInfo('', 'fields');
             }
             foreach ($this->data as $key => $val) {
                 if (!in_array($key, $this->field)) {
@@ -1785,7 +1785,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         // 记录当前关联信息
         $model      = $this->parseModel($model);
         $name       = Loader::parseName(basename(str_replace('\\', '/', $model)));
-        $table      = $table ?: $this->db(false)->getTable(Loader::parseName($this->name) . '_' . $name);
+        $table      = $table ?: $this->getQuery()->getTable(Loader::parseName($this->name) . '_' . $name);
         $foreignKey = $foreignKey ?: $name . '_id';
         $localKey   = $localKey ?: $this->getForeignKey($this->name);
         return new BelongsToMany($this, $model, $table, $foreignKey, $localKey);
@@ -1870,7 +1870,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
 
     public function __call($method, $args)
     {
-        $query = $this->db();
+        $query = $this->db(true, false);
 
         if (method_exists($this, 'scope' . $method)) {
             // 动态调用命名范围

--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -802,10 +802,12 @@ class Request
     public function cookie($name = '', $default = null, $filter = '')
     {
         if (empty($this->cookie)) {
-            $this->cookie = $_COOKIE;
+            $this->cookie = Cookie::get();
         }
         if (is_array($name)) {
             return $this->cookie = array_merge($this->cookie, $name);
+        } elseif (!empty($name)) {
+            $name = Cookie::prefix() . $name;
         }
         return $this->input($this->cookie, $name, $default, $filter);
     }

--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -1527,13 +1527,13 @@ class Request
                     }
                 }
                 // 自动缓存功能
-                $key = md5($this->host()) . '__URL__';
+                $key = '__URL__';
             } elseif (strpos($key, '|')) {
                 list($key, $fun) = explode('|', $key);
             }
             // 特殊规则替换
             if (false !== strpos($key, '__')) {
-                $key = str_replace(['__MODULE__', '__CONTROLLER__', '__ACTION__', '__URL__', ''], [$this->module, $this->controller, $this->action, md5($this->url())], $key);
+                $key = str_replace(['__MODULE__', '__CONTROLLER__', '__ACTION__', '__URL__', ''], [$this->module, $this->controller, $this->action, md5($this->url(true))], $key);
             }
 
             if (false !== strpos($key, ':')) {

--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -1057,7 +1057,7 @@ class Route
         if (!empty($array[1])) {
             self::parseUrlParams($array[1]);
         }
-        return ['type' => 'method', 'method' => [$class, $action]];
+        return ['type' => 'method', 'method' => [$class, $action], 'var' => []];
     }
 
     /**
@@ -1077,7 +1077,7 @@ class Route
         if (!empty($array[2])) {
             self::parseUrlParams($array[2]);
         }
-        return ['type' => 'method', 'method' => [$namespace . '\\' . Loader::parseName($class, 1), $method]];
+        return ['type' => 'method', 'method' => [$namespace . '\\' . Loader::parseName($class, 1), $method], 'var' => []];
     }
 
     /**
@@ -1096,7 +1096,7 @@ class Route
         if (!empty($array[1])) {
             self::parseUrlParams($array[1]);
         }
-        return ['type' => 'controller', 'controller' => $controller . '/' . $action];
+        return ['type' => 'controller', 'controller' => $controller . '/' . $action, 'var' => []];
     }
 
     /**

--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -1184,9 +1184,9 @@ class Route
                 }
             }
             $pattern = array_merge(self::$rules['pattern'], $pattern);
-            if (false !== $match = self::match($url, $rule, $pattern, $merge)) {
+            if (false !== $match = self::match($url, $rule, $pattern)) {
                 // 匹配到路由规则
-                return self::parseRule($rule, $route, $url, $option, $match, $merge);
+                return self::parseRule($rule, $route, $url, $option, $match);
             }
         }
         return false;

--- a/library/think/Session.php
+++ b/library/think/Session.php
@@ -56,7 +56,7 @@ class Session
             $isDoStart = true;
         }
 
-        if (isset($config['prefix'])) {
+        if (isset($config['prefix']) && (self::$prefix === '' || self::$prefix === null)) {
             self::$prefix = $config['prefix'];
         }
         if (isset($config['var_session_id']) && isset($_REQUEST[$config['var_session_id']])) {

--- a/library/think/Template.php
+++ b/library/think/Template.php
@@ -927,7 +927,7 @@ class Template
                         if (false === strpos($name, '(')) {
                             $name = '(isset(' . $name . ') && (' . $name . ' !== \'\')?' . $name . ':' . $args[1] . ')';
                         } else {
-                            $name = '(' . $name . ' !== \'\'?' . $name . ':' . $args[1] . ')';
+                            $name = '(' . $name . ' ?: ' . $args[1] . ')';
                         }
                         break;
                     default: // 通用模板函数

--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -456,11 +456,12 @@ class Validate
      * @access protected
      * @param mixed     $value  字段值
      * @param mixed     $rule  验证规则
+     * @param array     $data  数据
      * @return bool
      */
-    protected function egt($value, $rule)
+    protected function egt($value, $rule, $data)
     {
-        return $value >= $rule;
+        return !is_null($this->getDataValue($data, $rule)) && $value >= $this->getDataValue($data, $rule);
     }
 
     /**
@@ -468,11 +469,12 @@ class Validate
      * @access protected
      * @param mixed     $value  字段值
      * @param mixed     $rule  验证规则
+     * @param array     $data  数据
      * @return bool
      */
-    protected function gt($value, $rule)
+    protected function gt($value, $rule, $data)
     {
-        return $value > $rule;
+        return !is_null($this->getDataValue($data, $rule)) && $value > $this->getDataValue($data, $rule);
     }
 
     /**
@@ -480,11 +482,12 @@ class Validate
      * @access protected
      * @param mixed     $value  字段值
      * @param mixed     $rule  验证规则
+     * @param array     $data  数据
      * @return bool
      */
-    protected function elt($value, $rule)
+    protected function elt($value, $rule, $data)
     {
-        return $value <= $rule;
+        return !is_null($this->getDataValue($data, $rule)) && $value <= $this->getDataValue($data, $rule);
     }
 
     /**
@@ -492,11 +495,12 @@ class Validate
      * @access protected
      * @param mixed     $value  字段值
      * @param mixed     $rule  验证规则
+     * @param array     $data  数据
      * @return bool
      */
-    protected function lt($value, $rule)
+    protected function lt($value, $rule, $data)
     {
-        return $value < $rule;
+        return !is_null($this->getDataValue($data, $rule)) && $value < $this->getDataValue($data, $rule);
     }
 
     /**
@@ -1180,8 +1184,8 @@ class Validate
     /**
      * 获取数据值
      * @access protected
-     * @param array     $data  数据
-     * @param string    $key  数据标识 支持二维
+     * @param array $data 数据
+     * @param string $key 数据标识 支持二维
      * @return mixed
      */
     protected function getDataValue($data, $key)
@@ -1189,9 +1193,9 @@ class Validate
         if (strpos($key, '.')) {
             // 支持二维数组验证
             list($name1, $name2) = explode('.', $key);
-            $value               = isset($data[$name1][$name2]) ? $data[$name1][$name2] : null;
+            $value = isset($data[$name1][$name2]) ? $data[$name1][$name2] : null;
         } else {
-            $value = isset($data[$key]) ? $data[$key] : null;
+            $value = is_numeric($key) ? $key : (isset($data[$key]) ? $data[$key] : null);
         }
         return $value;
     }

--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -461,7 +461,8 @@ class Validate
      */
     protected function egt($value, $rule, $data)
     {
-        return !is_null($this->getDataValue($data, $rule)) && $value >= $this->getDataValue($data, $rule);
+        $val = $this->getDataValue($data, $rule);
+        return !is_null($val) && $value >= $val;
     }
 
     /**
@@ -474,7 +475,8 @@ class Validate
      */
     protected function gt($value, $rule, $data)
     {
-        return !is_null($this->getDataValue($data, $rule)) && $value > $this->getDataValue($data, $rule);
+        $val = $this->getDataValue($data, $rule);
+        return !is_null($val) && $value > $val;
     }
 
     /**
@@ -487,7 +489,8 @@ class Validate
      */
     protected function elt($value, $rule, $data)
     {
-        return !is_null($this->getDataValue($data, $rule)) && $value <= $this->getDataValue($data, $rule);
+        $val = $this->getDataValue($data, $rule);
+        return !is_null($val) && $value <= $val;
     }
 
     /**
@@ -500,7 +503,8 @@ class Validate
      */
     protected function lt($value, $rule, $data)
     {
-        return !is_null($this->getDataValue($data, $rule)) && $value < $this->getDataValue($data, $rule);
+        $val = $this->getDataValue($data, $rule);
+        return !is_null($val) && $value < $val;
     }
 
     /**
@@ -1193,7 +1197,7 @@ class Validate
         if (strpos($key, '.')) {
             // 支持二维数组验证
             list($name1, $name2) = explode('.', $key);
-            $value = isset($data[$name1][$name2]) ? $data[$name1][$name2] : null;
+            $value               = isset($data[$name1][$name2]) ? $data[$name1][$name2] : null;
         } else {
             $value = is_numeric($key) ? $key : (isset($data[$key]) ? $data[$key] : null);
         }

--- a/library/think/cache/driver/Memcache.php
+++ b/library/think/cache/driver/Memcache.php
@@ -113,7 +113,10 @@ class Memcache extends Driver
     public function inc($name, $step = 1)
     {
         $key = $this->getCacheKey($name);
-        return $this->handler->increment($key, $step);
+        if( $this->has($name) ){
+            return $this->handler->increment($key, $step);
+        }
+        return $this->handler->set($key, $step);
     }
 
     /**

--- a/library/think/cache/driver/Memcache.php
+++ b/library/think/cache/driver/Memcache.php
@@ -113,7 +113,7 @@ class Memcache extends Driver
     public function inc($name, $step = 1)
     {
         $key = $this->getCacheKey($name);
-        if( $this->has($name) ){
+        if ($this->handler->get($key)) {
             return $this->handler->increment($key, $step);
         }
         return $this->handler->set($key, $step);

--- a/library/think/cache/driver/Memcached.php
+++ b/library/think/cache/driver/Memcached.php
@@ -125,7 +125,10 @@ class Memcached extends Driver
     public function inc($name, $step = 1)
     {
         $key = $this->getCacheKey($name);
-        return $this->handler->increment($key, $step);
+        if( $this->has($name) ){
+            return $this->handler->increment($key, $step);
+        }
+        return $this->handler->set($key, $step);
     }
 
     /**

--- a/library/think/cache/driver/Memcached.php
+++ b/library/think/cache/driver/Memcached.php
@@ -125,7 +125,7 @@ class Memcached extends Driver
     public function inc($name, $step = 1)
     {
         $key = $this->getCacheKey($name);
-        if( $this->has($name) ){
+        if ($this->handler->get($key)) {
             return $this->handler->increment($key, $step);
         }
         return $this->handler->set($key, $step);

--- a/library/think/console/command/Clear.php
+++ b/library/think/console/command/Clear.php
@@ -28,17 +28,27 @@ class Clear extends Command
 
     protected function execute(Input $input, Output $output)
     {
-        $path  = $input->getOption('path') ?: RUNTIME_PATH;
+        $path = $input->getOption('path') ?: RUNTIME_PATH;
+
+        if (is_dir($path)) {
+            $this->clearPath($path);
+        }
+
+        $output->writeln("<info>Clear Successed</info>");
+    }
+
+    protected function clearPath($path)
+    {
+        $path  = realpath($path) . DS;
         $files = scandir($path);
         if ($files) {
             foreach ($files as $file) {
                 if ('.' != $file && '..' != $file && is_dir($path . $file)) {
-                    array_map('unlink', glob($path . $file . '/*.*'));
+                    $this->clearPath($path . $file);
                 } elseif ('.gitignore' != $file && is_file($path . $file)) {
                     unlink($path . $file);
                 }
             }
         }
-        $output->writeln("<info>Clear Successed</info>");
     }
 }

--- a/library/think/console/command/optimize/Autoload.php
+++ b/library/think/console/command/optimize/Autoload.php
@@ -132,7 +132,7 @@ EOF;
     protected function normalizePath($path)
     {
         if ($path === false) {
-            return null;
+            return;
         }
         $parts    = [];
         $path     = strtr($path, '\\', '/');

--- a/library/think/console/command/optimize/Autoload.php
+++ b/library/think/console/command/optimize/Autoload.php
@@ -11,6 +11,7 @@
 namespace think\console\command\optimize;
 
 use think\App;
+use think\Config;
 use think\console\Command;
 use think\console\Input;
 use think\console\Output;
@@ -32,7 +33,7 @@ class Autoload extends Command
 /**
  * 类库映射
  */
- 
+
 return [
 
 EOF;
@@ -42,8 +43,13 @@ EOF;
             'think\\'              => LIB_PATH . 'think',
             'behavior\\'           => LIB_PATH . 'behavior',
             'traits\\'             => LIB_PATH . 'traits',
-            ''                     => realpath(rtrim(EXTEND_PATH))
+            ''                     => realpath(rtrim(EXTEND_PATH)),
         ];
+
+        $root_namespace = Config::get('root_namespace');
+        foreach ($root_namespace as $namespace => $dir) {
+            $namespacesToScan[$namespace . '\\'] = realpath($dir);
+        }
 
         krsort($namespacesToScan);
         $classMap = [];
@@ -84,7 +90,7 @@ EOF;
                 $this->output->writeln(
                     '<warning>Warning: Ambiguous class resolution, "' . $class . '"' .
                     ' was found in both "' . str_replace(["',\n"], [
-                        ''
+                        '',
                     ], $classMap[$class]) . '" and "' . $path . '", the first will be used.</warning>'
                 );
             }
@@ -96,20 +102,24 @@ EOF;
     {
 
         $baseDir    = '';
-        $appPath    = $this->normalizePath(realpath(APP_PATH));
         $libPath    = $this->normalizePath(realpath(LIB_PATH));
+        $appPath    = $this->normalizePath(realpath(APP_PATH));
         $extendPath = $this->normalizePath(realpath(EXTEND_PATH));
+        $rootPath   = $this->normalizePath(realpath(ROOT_PATH));
         $path       = $this->normalizePath($path);
 
-        if (strpos($path, $libPath . '/') === 0) {
+        if ($libPath !== null && strpos($path, $libPath . '/') === 0) {
             $path    = substr($path, strlen(LIB_PATH));
             $baseDir = 'LIB_PATH';
-        } elseif (strpos($path, $appPath . '/') === 0) {
+        } elseif ($appPath !== null && strpos($path, $appPath . '/') === 0) {
             $path    = substr($path, strlen($appPath) + 1);
             $baseDir = 'APP_PATH';
-        } elseif (strpos($path, $extendPath . '/') === 0) {
+        } elseif ($extendPath !== null && strpos($path, $extendPath . '/') === 0) {
             $path    = substr($path, strlen($extendPath) + 1);
             $baseDir = 'EXTEND_PATH';
+        } elseif ($rootPath !== null && strpos($path, $rootPath . '/') === 0) {
+            $path    = substr($path, strlen($rootPath) + 1);
+            $baseDir = 'ROOT_PATH';
         }
 
         if ($path !== false) {
@@ -121,6 +131,9 @@ EOF;
 
     protected function normalizePath($path)
     {
+        if ($path === false) {
+            return null;
+        }
         $parts    = [];
         $path     = strtr($path, '\\', '/');
         $prefix   = '';

--- a/library/think/console/command/optimize/Schema.php
+++ b/library/think/console/command/optimize/Schema.php
@@ -25,6 +25,7 @@ class Schema extends Command
     protected function configure()
     {
         $this->setName('optimize:schema')
+            ->addOption('config', null, Option::VALUE_REQUIRED, 'db config .')
             ->addOption('db', null, Option::VALUE_REQUIRED, 'db name .')
             ->addOption('table', null, Option::VALUE_REQUIRED, 'table name .')
             ->addOption('module', null, Option::VALUE_REQUIRED, 'module name .')
@@ -35,6 +36,10 @@ class Schema extends Command
     {
         if (!is_dir(RUNTIME_PATH . 'schema')) {
             @mkdir(RUNTIME_PATH . 'schema', 0755, true);
+        }
+        $config = [];
+        if ($input->hasOption('config')) {
+            $config = $input->getOption('config');
         }
         if ($input->hasOption('module')) {
             $module = $input->getOption('module');
@@ -53,12 +58,12 @@ class Schema extends Command
         } elseif ($input->hasOption('table')) {
             $table = $input->getOption('table');
             if (!strpos($table, '.')) {
-                $dbName = Db::getConfig('database');
+                $dbName = Db::connect($config)->getConfig('database');
             }
             $tables[] = $table;
         } elseif ($input->hasOption('db')) {
             $dbName = $input->getOption('db');
-            $tables = Db::getTables($dbName);
+            $tables = Db::connect($config)->getTables($dbName);
         } elseif (!\think\Config::get('app_multi_module')) {
             $app  = App::$namespace;
             $list = scandir(APP_PATH . 'model');
@@ -72,11 +77,11 @@ class Schema extends Command
             $output->writeln('<info>Succeed!</info>');
             return;
         } else {
-            $tables = Db::getTables();
+            $tables = Db::connect($config)->getTables();
         }
 
         $db = isset($dbName) ? $dbName . '.' : '';
-        $this->buildDataBaseSchema($tables, $db);
+        $this->buildDataBaseSchema($tables, $db, $config);
 
         $output->writeln('<info>Succeed!</info>');
     }
@@ -94,16 +99,16 @@ class Schema extends Command
         }
     }
 
-    protected function buildDataBaseSchema($tables, $db)
+    protected function buildDataBaseSchema($tables, $db, $config)
     {
         if ('' == $db) {
-            $dbName = Db::getConfig('database') . '.';
+            $dbName = Db::connect($config)->getConfig('database') . '.';
         } else {
             $dbName = $db;
         }
         foreach ($tables as $table) {
             $content = '<?php ' . PHP_EOL . 'return ';
-            $info    = Db::getFields($db . $table);
+            $info    = Db::connect($config)->getFields($db . $table);
             $content .= var_export($info, true) . ';';
             file_put_contents(RUNTIME_PATH . 'schema' . DS . $dbName . $table . EXT, $content);
         }

--- a/library/think/console/command/optimize/Schema.php
+++ b/library/think/console/command/optimize/Schema.php
@@ -42,7 +42,7 @@ class Schema extends Command
             $list = scandir(APP_PATH . $module . DS . 'model');
             $app  = App::$namespace;
             foreach ($list as $file) {
-                if ('.' == $file || '..' == $file) {
+                if (0 === strpos($file, '.')) {
                     continue;
                 }
                 $class = '\\' . $app . '\\' . $module . '\\model\\' . pathinfo($file, PATHINFO_FILENAME);
@@ -63,7 +63,7 @@ class Schema extends Command
             $app  = App::$namespace;
             $list = scandir(APP_PATH . 'model');
             foreach ($list as $file) {
-                if ('.' == $file || '..' == $file) {
+                if (0 === strpos($file, '.')) {
                     continue;
                 }
                 $class = '\\' . $app . '\\model\\' . pathinfo($file, PATHINFO_FILENAME);

--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -222,6 +222,14 @@ abstract class Builder
     protected function parseWhere($where, $options)
     {
         $whereStr = $this->buildWhere($where, $options);
+        if (!empty($options['soft_delete'])) {
+            // 附加软删除条件
+            list($field, $condition) = $options['soft_delete'];
+
+            $binds    = $this->query->getFieldsBind($options);
+            $whereStr = $whereStr ? '( ' . $whereStr . ' ) AND ' : '';
+            $whereStr = $whereStr . $this->parseWhereItem($field, $condition, '', $options, $binds);
+        }
         return empty($whereStr) ? '' : ' WHERE ' . $whereStr;
     }
 
@@ -280,13 +288,7 @@ abstract class Builder
 
             $whereStr .= empty($whereStr) ? substr(implode(' ', $str), strlen($key) + 1) : implode(' ', $str);
         }
-        if (!empty($options['soft_delete'])) {
-            // 附加软删除条件
-            list($field, $condition) = $options['soft_delete'];
 
-            $whereStr = $whereStr ? '( ' . $whereStr . ' ) AND ' : '';
-            $whereStr = $whereStr . $this->parseWhereItem($field, $condition, '', $options, $binds);
-        }
         return $whereStr;
     }
 

--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -280,6 +280,13 @@ abstract class Builder
 
             $whereStr .= empty($whereStr) ? substr(implode(' ', $str), strlen($key) + 1) : implode(' ', $str);
         }
+        if (!empty($options['soft_delete'])) {
+            // 附加软删除条件
+            list($field, $condition) = $options['soft_delete'];
+
+            $whereStr = $whereStr ? '( ' . $whereStr . ' ) AND ' : '';
+            $whereStr = $whereStr . $this->parseWhereItem($field, $condition, '', $options, $binds);
+        }
         return $whereStr;
     }
 

--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -98,15 +98,16 @@ abstract class Builder
         $result = [];
         foreach ($data as $key => $val) {
             $item = $this->parseKey($key, $options);
+            if (is_object($val) && method_exists($val, '__toString')) {
+                // 对象数据写入
+                $val = $val->__toString();
+            }
             if (false === strpos($key, '.') && !in_array($key, $fields, true)) {
                 if ($options['strict']) {
                     throw new Exception('fields not exists:[' . $key . ']');
                 }
             } elseif (is_null($val)) {
                 $result[$item] = 'NULL';
-            } elseif (is_object($val) && method_exists($val, '__toString')) {
-                // 对象数据写入
-                $result[$item] = $val->__toString();
             } elseif (isset($val[0]) && 'exp' == $val[0]) {
                 $result[$item] = $val[1];
             } elseif (is_scalar($val)) {

--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -102,10 +102,13 @@ abstract class Builder
                 if ($options['strict']) {
                     throw new Exception('fields not exists:[' . $key . ']');
                 }
-            } elseif (isset($val[0]) && 'exp' == $val[0]) {
-                $result[$item] = $val[1];
             } elseif (is_null($val)) {
                 $result[$item] = 'NULL';
+            } elseif (is_object($val) && method_exists($val, '__toString')) {
+                // 对象数据写入
+                $result[$item] = $val->__toString();
+            } elseif (isset($val[0]) && 'exp' == $val[0]) {
+                $result[$item] = $val[1];
             } elseif (is_scalar($val)) {
                 // 过滤非标量数据
                 if (0 === strpos($val, ':') && $this->query->isBind(substr($val, 1))) {
@@ -115,9 +118,6 @@ abstract class Builder
                     $this->query->bind('__data__' . $key, $val, isset($bind[$key]) ? $bind[$key] : PDO::PARAM_STR);
                     $result[$item] = ':__data__' . $key;
                 }
-            } elseif (is_object($val) && method_exists($val, '__toString')) {
-                // 对象数据写入
-                $result[$item] = $val->__toString();
             }
         }
         return $result;

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -57,7 +57,7 @@ abstract class Connection
     // 监听回调
     protected static $event = [];
     // 查询对象
-    protected $query;
+    protected $query = [];
     // 使用Builder类
     protected $builder;
     // 数据库连接参数配置
@@ -142,9 +142,9 @@ abstract class Connection
      * @param Query $query 查询对象
      * @return $this
      */
-    public function setQuery($query)
+    public function setQuery($query, $model = 'db')
     {
-        $this->query = $query;
+        $this->query[$model] = $query;
 
         return $this;
     }
@@ -154,15 +154,15 @@ abstract class Connection
      * @access public
      * @return Query
      */
-    public function getQuery()
+    public function getQuery($model = 'db')
     {
-        if (!isset($this->query)) {
+        if (!isset($this->query[$model])) {
             $class = $this->config['query'];
 
-            $this->query = new $class($this);
+            $this->query[$model] = new $class($this, 'db' == $model ? '' : $model);
         }
 
-        return $this->query;
+        return $this->query[$model];
     }
 
     /**

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -340,13 +340,9 @@ abstract class Connection
     /**
      * 执行查询 返回数据集
      * @access public
-     * @param string    $sql sql指令
-     * @param array     $bind 参数绑定
-     * @param bool      $master 是否在主服务器读操作
-     * @param bool      $class 是否返回PDO对象
      * @param string        $sql sql指令
      * @param array         $bind 参数绑定
-     * @param boolean       $master 是否在主服务器读操作
+     * @param bool          $master 是否在主服务器读操作
      * @param bool          $pdo 是否返回PDO对象
      * @return mixed
      * @throws BindParamException

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -57,7 +57,7 @@ abstract class Connection
     // 监听回调
     protected static $event = [];
     // 查询对象
-    protected $query = [];
+    protected $query;
     // 使用Builder类
     protected $builder;
     // 数据库连接参数配置
@@ -137,19 +137,32 @@ abstract class Connection
     }
 
     /**
+     * 指定当前使用的查询对象
+     * @access public
+     * @param Query $query 查询对象
+     * @return $this
+     */
+    public function setQuery($query)
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    /**
      * 创建指定模型的查询对象
      * @access public
-     * @param string $model 模型类名称
-     * @param string $queryClass 查询对象类名
      * @return Query
      */
-    public function getQuery($model = 'db', $queryClass = '')
+    public function getQuery()
     {
-        if (!isset($this->query[$model])) {
-            $class               = $queryClass ?: $this->config['query'];
-            $this->query[$model] = new $class($this, 'db' == $model ? '' : $model);
+        if (!isset($this->query)) {
+            $class = $this->config['query'];
+
+            $this->query = new $class($this);
         }
-        return $this->query[$model];
+
+        return $this->query;
     }
 
     /**

--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -1121,6 +1121,20 @@ class Query
     }
 
     /**
+     * 设置软删除字段及条件
+     * @access public
+     * @param false|string  $field     查询字段
+     * @param mixed         $condition 查询条件
+     * @return $this
+     */
+    public function useSoftDelete($field, $condition = null)
+    {
+        if ($field) {
+            $this->options['soft_delete'] = [$field, $condition ?: ['null', '']];
+        }
+    }
+
+    /**
      * 分析查询表达式
      * @access public
      * @param string                $logic     查询逻辑 and or xor

--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -451,7 +451,9 @@ class Query
             if (isset($this->options['field'])) {
                 unset($this->options['field']);
             }
-            if ($key && '*' != $field) {
+            if (is_null($field)) {
+                $field = '*';
+            } elseif ($key && '*' != $field) {
                 $field = $key . ',' . $field;
             }
             $pdo = $this->field($field)->getPdo();

--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -1911,7 +1911,7 @@ class Query
             $relation = Loader::parseName($relation, 1, false);
             $model    = $class->$relation();
             if ($model instanceof OneToOne && 0 == $model->getEagerlyType()) {
-                $model->removeOption()->eagerly($this, $relation, $subRelation, $closure, $first);
+                $model->eagerly($this, $relation, $subRelation, $closure, $first);
                 $first = false;
             } elseif ($closure) {
                 $with[$key] = $closure;

--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -651,16 +651,16 @@ class Query
         if (!Cache::has($guid . '_time')) {
             // 计时开始
             Cache::set($guid . '_time', $_SERVER['REQUEST_TIME'], 0);
-            Cache::$type($guid, $step, 0);
+            Cache::$type($guid, $step);
         } elseif ($_SERVER['REQUEST_TIME'] > Cache::get($guid . '_time') + $lazyTime) {
             // 删除缓存
-            $value = Cache::$type($guid, $step, 0);
+            $value = Cache::$type($guid, $step);
             Cache::rm($guid);
             Cache::rm($guid . '_time');
             return 0 === $value ? false : $value;
         } else {
             // 更新缓存
-            Cache::$type($guid, $step, 0);
+            Cache::$type($guid, $step);
         }
         return false;
     }

--- a/library/think/db/builder/Mysql.php
+++ b/library/think/db/builder/Mysql.php
@@ -47,6 +47,9 @@ class Mysql extends Builder
             $key = '`' . $key . '`';
         }
         if (isset($table)) {
+            if (strpos($table, '.')) {
+                $table = str_replace('.', '`.`', $table);
+            }
             $key = '`' . $table . '`.' . $key;
         }
         return $key;

--- a/library/think/log/driver/File.php
+++ b/library/think/log/driver/File.php
@@ -25,6 +25,8 @@ class File
         'apart_level' => [],
     ];
 
+    protected $writed = [];
+
     // 实例化并传入参数
     public function __construct($config = [])
     {
@@ -37,45 +39,17 @@ class File
      * 日志写入接口
      * @access public
      * @param array $log 日志信息
-     * @param bool  $depr 是否写入分割线
      * @return bool
      */
-    public function save(array $log = [], $depr = true)
+    public function save(array $log = [])
     {
-        $now         = date($this->config['time_format']);
-        $destination = $this->config['path'] . date('Ym') . DS . date('d') . '.log';
+        $cli         = IS_CLI ? '_cli' : '';
+        $destination = $this->config['path'] . date('Ym') . DS . date('d') . $cli . '.log';
 
         $path = dirname($destination);
         !is_dir($path) && mkdir($path, 0755, true);
 
-        //检测日志文件大小，超过配置大小则备份日志文件重新生成
-        if (is_file($destination) && floor($this->config['file_size']) <= filesize($destination)) {
-            rename($destination, dirname($destination) . DS . $_SERVER['REQUEST_TIME'] . '-' . basename($destination));
-        }
-
-        $depr = $depr ? "---------------------------------------------------------------\r\n" : '';
         $info = '';
-        if (App::$debug) {
-            // 获取基本信息
-            if (isset($_SERVER['HTTP_HOST'])) {
-                $current_uri = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-            } else {
-                $current_uri = "cmd:" . implode(' ', $_SERVER['argv']);
-            }
-
-            $runtime    = round(microtime(true) - THINK_START_TIME, 10);
-            $reqs       = $runtime > 0 ? number_format(1 / $runtime, 2) : '∞';
-            $time_str   = ' [运行时间：' . number_format($runtime, 6) . 's][吞吐率：' . $reqs . 'req/s]';
-            $memory_use = number_format((memory_get_usage() - THINK_START_MEM) / 1024, 2);
-            $memory_str = ' [内存消耗：' . $memory_use . 'kb]';
-            $file_load  = ' [文件加载：' . count(get_included_files()) . ']';
-
-            $info   = '[ log ] ' . $current_uri . $time_str . $memory_str . $file_load . "\r\n";
-            $server = isset($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : '0.0.0.0';
-            $remote = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '0.0.0.0';
-            $method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'CLI';
-            $uri    = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
-        }
         foreach ($log as $type => $val) {
             $level = '';
             foreach ($val as $msg) {
@@ -86,16 +60,60 @@ class File
             }
             if (in_array($type, $this->config['apart_level'])) {
                 // 独立记录的日志级别
-                $filename = $path . DS . date('d') . '_' . $type . '.log';
-                error_log("[{$now}] {$level}\r\n{$depr}", 3, $filename);
+                $filename = $path . DS . date('d') . '_' . $type . $cli . '.log';
+                $this->write($level, $filename, true);
             } else {
                 $info .= $level;
             }
         }
-        if (App::$debug) {
-            $info = "{$server} {$remote} {$method} {$uri}\r\n" . $info;
+        if ($info) {
+            return $this->write($info, $destination);
         }
-        return error_log("[{$now}] {$info}\r\n{$depr}", 3, $destination);
+        return true;
+    }
+
+    protected function write($message, $destination, $apart = false)
+    {
+        //检测日志文件大小，超过配置大小则备份日志文件重新生成
+        if (is_file($destination) && floor($this->config['file_size']) <= filesize($destination)) {
+            rename($destination, dirname($destination) . DS . $_SERVER['REQUEST_TIME'] . '-' . basename($destination));
+            $this->writed[$destination] = false;
+        }
+
+        if (empty($this->writed[$destination]) && !IS_CLI) {
+            if (App::$debug && !$apart) {
+                // 获取基本信息
+                if (isset($_SERVER['HTTP_HOST'])) {
+                    $current_uri = $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+                } else {
+                    $current_uri = "cmd:" . implode(' ', $_SERVER['argv']);
+                }
+
+                $runtime    = round(microtime(true) - THINK_START_TIME, 10);
+                $reqs       = $runtime > 0 ? number_format(1 / $runtime, 2) : '∞';
+                $time_str   = ' [运行时间：' . number_format($runtime, 6) . 's][吞吐率：' . $reqs . 'req/s]';
+                $memory_use = number_format((memory_get_usage() - THINK_START_MEM) / 1024, 2);
+                $memory_str = ' [内存消耗：' . $memory_use . 'kb]';
+                $file_load  = ' [文件加载：' . count(get_included_files()) . ']';
+
+                $message = '[ info ] ' . $current_uri . $time_str . $memory_str . $file_load . "\r\n" . $message;
+            }
+            $now     = date($this->config['time_format']);
+            $server  = isset($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : '0.0.0.0';
+            $remote  = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '0.0.0.0';
+            $method  = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'CLI';
+            $uri     = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
+            $message = "---------------------------------------------------------------\r\n[{$now}] {$server} {$remote} {$method} {$uri}\r\n" . $message;
+
+            $this->writed[$destination] = true;
+        }
+
+        if (IS_CLI) {
+            $now     = date($this->config['time_format']);
+            $message = "[{$now}]" . $message;
+        }
+
+        return error_log($message, 3, $destination);
     }
 
 }

--- a/library/think/model/Pivot.php
+++ b/library/think/model/Pivot.php
@@ -16,19 +16,25 @@ use think\Model;
 class Pivot extends Model
 {
 
+    /** @var Model */
+    public $parent;
+
     /**
      * 构造函数
      * @access public
-     * @param array|object $data 数据
-     * @param string $table 中间数据表名
+     * @param Model        $parent
+     * @param array|object $data  数据
+     * @param string       $table 中间数据表名
      */
-    public function __construct($data = [], $table = '')
+    public function __construct(Model $parent, $data = [], $table = '')
     {
         if (is_object($data)) {
             $this->data = get_object_vars($data);
         } else {
             $this->data = $data;
         }
+
+        $this->parent = $parent;
 
         $this->table = $table;
     }

--- a/library/think/model/Pivot.php
+++ b/library/think/model/Pivot.php
@@ -35,8 +35,9 @@ class Pivot extends Model
         }
 
         $this->parent = $parent;
-
-        $this->table = $table;
+        if (is_null($this->name)) {
+            $this->name = $table;
+        }
     }
 
 }

--- a/library/think/model/Pivot.php
+++ b/library/think/model/Pivot.php
@@ -19,25 +19,26 @@ class Pivot extends Model
     /** @var Model */
     public $parent;
 
+    protected $autoWriteTimestamp = false;
+
     /**
-     * 构造函数
+     * 架构函数
      * @access public
-     * @param Model        $parent
-     * @param array|object $data  数据
-     * @param string       $table 中间数据表名
+     * @param Model         $parent 上级模型
+     * @param array|object  $data 数据
+     * @param string        $table 中间数据表名
      */
     public function __construct(Model $parent, $data = [], $table = '')
     {
-        if (is_object($data)) {
-            $this->data = get_object_vars($data);
-        } else {
-            $this->data = $data;
-        }
-
         $this->parent = $parent;
+
         if (is_null($this->name)) {
             $this->name = $table;
         }
+
+        parent::__construct($data);
+
+        $this->class = $this->name;
     }
 
 }

--- a/library/think/model/Relation.php
+++ b/library/think/model/Relation.php
@@ -91,7 +91,7 @@ abstract class Relation
     }
 
     /**
-     * 执行基础查询（进执行一次）
+     * 执行基础查询（仅执行一次）
      * @access protected
      * @return void
      */

--- a/library/think/model/Relation.php
+++ b/library/think/model/Relation.php
@@ -33,8 +33,6 @@ abstract class Relation
     protected $foreignKey;
     // 关联表主键
     protected $localKey;
-    // 关联查询参数
-    protected $option;
     // 基础查询
     protected $baseQuery;
 
@@ -80,17 +78,6 @@ abstract class Relation
     }
 
     /**
-     * 移除关联查询参数
-     * @access public
-     * @return $this
-     */
-    public function removeOption()
-    {
-        $this->query->removeOption();
-        return $this;
-    }
-
-    /**
      * 执行基础查询（仅执行一次）
      * @access protected
      * @return void
@@ -105,10 +92,8 @@ abstract class Relation
 
             $result = call_user_func_array([$this->query, $method], $args);
             if ($result instanceof Query) {
-                $this->option = $result->getOptions();
                 return $this;
             } else {
-                $this->option    = [];
                 $this->baseQuery = false;
                 return $result;
             }

--- a/library/think/model/relation/BelongsTo.php
+++ b/library/think/model/relation/BelongsTo.php
@@ -50,7 +50,16 @@ class BelongsTo extends OneToOne
         if ($closure) {
             call_user_func_array($closure, [ & $this->query]);
         }
-        return $this->query->where($this->localKey, $this->parent->$foreignKey)->relation($subRelation)->find();
+        $relationModel = $this->query
+            ->where($this->localKey, $this->parent->$foreignKey)
+            ->relation($subRelation)
+            ->find();
+
+        if ($relationModel) {
+            $relationModel->setParent(clone $this->parent);
+        }
+
+        return $relationModel;
     }
 
     /**
@@ -130,6 +139,8 @@ class BelongsTo extends OneToOne
                     $relationModel = null;
                 } else {
                     $relationModel = $data[$result->$foreignKey];
+                    $relationModel->setParent(clone $result);
+                    $relationModel->isUpdate(true);
                 }
 
                 if ($relationModel && !empty($this->bindAttr)) {
@@ -161,6 +172,8 @@ class BelongsTo extends OneToOne
             $relationModel = null;
         } else {
             $relationModel = $data[$result->$foreignKey];
+            $relationModel->setParent(clone $result);
+            $relationModel->isUpdate(true);
         }
         if ($relationModel && !empty($this->bindAttr)) {
             // 绑定关联属性

--- a/library/think/model/relation/BelongsTo.php
+++ b/library/think/model/relation/BelongsTo.php
@@ -25,7 +25,7 @@ class BelongsTo extends OneToOne
      * @param string $localKey 关联主键
      * @param string $joinType JOIN类型
      */
-    public function __construct(Model $parent, $model, $foreignKey, $localKey, $joinType = 'INNER')
+    public function __construct(Model $parent, $model, $foreignKey, $localKey, $joinType = 'INNER', $relation = null)
     {
         $this->parent     = $parent;
         $this->model      = $model;
@@ -33,6 +33,7 @@ class BelongsTo extends OneToOne
         $this->localKey   = $localKey;
         $this->joinType   = $joinType;
         $this->query      = (new $model)->db();
+        $this->relation   = $realtion;
     }
 
     /**
@@ -168,4 +169,35 @@ class BelongsTo extends OneToOne
         $result->setAttr(Loader::parseName($relation), $relationModel);
     }
 
+    /**
+     * 添加关联数据
+     * @access public
+     * @param Model $model       关联模型对象
+     * @return Model
+     */
+    public function associate($model)
+    {
+        $foreignKey = $this->foreignKey;
+        $pk         = $model->getPk();
+
+        $this->parent->setAttr($foreignKey, $model->$pk);
+        $this->parent->save();
+
+        return $this->parent->setAttr($this->relation, $model);
+    }
+
+    /**
+     * 注销关联数据
+     * @access public
+     * @return Model
+     */
+    public function dissociate()
+    {
+        $foreignKey = $this->foreignKey;
+
+        $this->parent->setAttr($foreignKey, null);
+        $this->parent->save();
+
+        return $this->parent->setAttr($this->relation, null);
+    }
 }

--- a/library/think/model/relation/BelongsTo.php
+++ b/library/think/model/relation/BelongsTo.php
@@ -34,7 +34,7 @@ class BelongsTo extends OneToOne
         $this->localKey   = $localKey;
         $this->joinType   = $joinType;
         $this->query      = (new $model)->db();
-        $this->relation   = $realtion;
+        $this->relation   = $relation;
     }
 
     /**

--- a/library/think/model/relation/BelongsTo.php
+++ b/library/think/model/relation/BelongsTo.php
@@ -24,6 +24,7 @@ class BelongsTo extends OneToOne
      * @param string $foreignKey 关联外键
      * @param string $localKey 关联主键
      * @param string $joinType JOIN类型
+     * @param string $relation  关联名
      */
     public function __construct(Model $parent, $model, $foreignKey, $localKey, $joinType = 'INNER', $relation = null)
     {

--- a/library/think/model/relation/BelongsTo.php
+++ b/library/think/model/relation/BelongsTo.php
@@ -184,7 +184,7 @@ class BelongsTo extends OneToOne
         $this->parent->setAttr($foreignKey, $model->$pk);
         $this->parent->save();
 
-        return $this->parent->setAttr($this->relation, $model);
+        return $this->parent->data($this->relation, $model);
     }
 
     /**
@@ -199,6 +199,6 @@ class BelongsTo extends OneToOne
         $this->parent->setAttr($foreignKey, null);
         $this->parent->save();
 
-        return $this->parent->setAttr($this->relation, null);
+        return $this->parent->data($this->relation, null);
     }
 }

--- a/library/think/model/relation/BelongsToMany.php
+++ b/library/think/model/relation/BelongsToMany.php
@@ -24,8 +24,9 @@ class BelongsToMany extends Relation
 {
     // 中间表表名
     protected $middle;
-
-    // 中间表模型
+    // 中间表模型名称
+    protected $pivotName;
+    // 中间表模型对象
     protected $pivot;
 
     /**
@@ -43,8 +44,13 @@ class BelongsToMany extends Relation
         $this->model      = $model;
         $this->foreignKey = $foreignKey;
         $this->localKey   = $localKey;
-        $this->middle     = $table;
-        $this->query      = (new $model)->db();
+        if (false === strpos($table, '\\')) {
+            $this->middle = $table;
+        } else {
+            $this->pivotName = $table;
+        }
+        $this->query = (new $model)->db();
+        $this->pivot = $this->newPivot();
     }
 
     /**
@@ -54,7 +60,7 @@ class BelongsToMany extends Relation
      */
     public function pivot($pivot)
     {
-        $this->pivot = $pivot;
+        $this->pivotName = $pivot;
         return $this;
     }
 
@@ -63,9 +69,9 @@ class BelongsToMany extends Relation
      * @param $data
      * @return mixed
      */
-    protected function newPivot($data)
+    protected function newPivot($data = [])
     {
-        $pivot = $this->pivot ?: '\\think\\model\\Pivot';
+        $pivot = $this->pivotName ?: '\\think\\model\\Pivot';
         return new $pivot($this->parent, $data, $this->middle);
     }
 
@@ -102,7 +108,7 @@ class BelongsToMany extends Relation
         // 关联查询
         $pk                              = $this->parent->getPk();
         $condition['pivot.' . $localKey] = $this->parent->$pk;
-        return $this->belongsToManyQuery($middle, $foreignKey, $localKey, $condition);
+        return $this->belongsToManyQuery($foreignKey, $localKey, $condition);
     }
 
     /**
@@ -114,7 +120,7 @@ class BelongsToMany extends Relation
     public function getRelation($subRelation = '', $closure = null)
     {
         if ($closure) {
-            call_user_func_array($closure, [& $this->query]);
+            call_user_func_array($closure, [ & $this->query]);
         }
         $result = $this->buildQuery()->relation($subRelation)->select();
         $this->hydratePivot($result);
@@ -303,7 +309,7 @@ class BelongsToMany extends Relation
         $count = 0;
         if (isset($result->$pk)) {
             $pk    = $result->$pk;
-            $count = $this->belongsToManyQuery($this->middle, $this->foreignKey, $this->localKey, ['pivot.' . $this->localKey => $pk])->count();
+            $count = $this->belongsToManyQuery($this->foreignKey, $this->localKey, ['pivot.' . $this->localKey => $pk])->count();
         }
         return $count;
     }
@@ -316,7 +322,7 @@ class BelongsToMany extends Relation
      */
     public function getRelationCountQuery($closure)
     {
-        return $this->belongsToManyQuery($this->middle, $this->foreignKey, $this->localKey, [
+        return $this->belongsToManyQuery($this->foreignKey, $this->localKey, [
             'pivot.' . $this->localKey => [
                 'exp',
                 '=' . $this->parent->getTable() . '.' . $this->parent->getPk(),
@@ -335,7 +341,7 @@ class BelongsToMany extends Relation
     protected function eagerlyManyToMany($where, $relation, $subRelation = '')
     {
         // 预载入关联查询 支持嵌套预载入
-        $list = $this->belongsToManyQuery($this->middle, $this->foreignKey, $this->localKey, $where)->with($subRelation)->select();
+        $list = $this->belongsToManyQuery($this->foreignKey, $this->localKey, $where)->with($subRelation)->select();
 
         // 组装模型数据
         $data = [];
@@ -359,13 +365,12 @@ class BelongsToMany extends Relation
     /**
      * BELONGS TO MANY 关联查询
      * @access public
-     * @param string $table      中间表名
      * @param string $foreignKey 关联模型关联键
      * @param string $localKey   当前模型关联键
      * @param array  $condition  关联查询条件
      * @return Query
      */
-    protected function belongsToManyQuery($table, $foreignKey, $localKey, $condition = [])
+    protected function belongsToManyQuery($foreignKey, $localKey, $condition = [])
     {
         // 关联查询封装
         $tableName  = $this->query->getTable();
@@ -374,6 +379,7 @@ class BelongsToMany extends Relation
             ->field(true, false, $table, 'pivot', 'pivot__');
 
         if (empty($this->baseQuery)) {
+            $table = $this->pivot->getTable();
             $query->join($table . ' pivot', 'pivot.' . $foreignKey . '=' . $tableName . '.' . $relationFk)
                 ->where($condition);
         }
@@ -450,7 +456,7 @@ class BelongsToMany extends Relation
             $ids                    = (array) $id;
             foreach ($ids as $id) {
                 $pivot[$this->foreignKey] = $id;
-                $this->query->table($this->middle)->insert($pivot, true);
+                $this->pivot->insert($pivot, true);
                 $result[] = $this->newPivot($pivot);
             }
             if (count($result) == 1) {
@@ -488,8 +494,7 @@ class BelongsToMany extends Relation
         if (isset($id)) {
             $pivot[$this->foreignKey] = is_array($id) ? ['in', $id] : $id;
         }
-        $this->query->table($this->middle)->where($pivot)->delete();
-
+        $this->pivot->where($pivot)->delete();
         // 删除关联表数据
         if (isset($id) && $relationDel) {
             $model = $this->model;
@@ -505,8 +510,9 @@ class BelongsToMany extends Relation
     protected function baseQuery()
     {
         if (empty($this->baseQuery)) {
-            $pk = $this->parent->getPk();
-            $this->query->join($this->middle . ' pivot', 'pivot.' . $this->foreignKey . '=' . $this->query->getTable() . '.' . $this->query->getPk())->where('pivot.' . $this->localKey, $this->parent->$pk);
+            $pk    = $this->parent->getPk();
+            $table = $this->pivot->getTable();
+            $this->query->join($table . ' pivot', 'pivot.' . $this->foreignKey . '=' . $this->query->getTable() . '.' . $this->query->getPk())->where('pivot.' . $this->localKey, $this->parent->$pk);
             $this->baseQuery = true;
         }
     }

--- a/library/think/model/relation/BelongsToMany.php
+++ b/library/think/model/relation/BelongsToMany.php
@@ -376,11 +376,11 @@ class BelongsToMany extends Relation
         // 关联查询封装
         $tableName  = $this->query->getTable();
         $relationFk = $this->query->getPk();
+        $table      = $this->pivot->getTable();
         $query      = $this->query->field($tableName . '.*')
             ->field(true, false, $table, 'pivot', 'pivot__');
 
         if (empty($this->baseQuery)) {
-            $table = $this->pivot->getTable();
             $query->join($table . ' pivot', 'pivot.' . $foreignKey . '=' . $tableName . '.' . $relationFk)
                 ->where($condition);
         }

--- a/library/think/model/relation/BelongsToMany.php
+++ b/library/think/model/relation/BelongsToMany.php
@@ -374,13 +374,13 @@ class BelongsToMany extends Relation
     protected function belongsToManyQuery($foreignKey, $localKey, $condition = [])
     {
         // 关联查询封装
-        $tableName  = $this->query->getTable();
-        $relationFk = $this->query->getPk();
-        $table      = $this->pivot->getTable();
-        $query      = $this->query->field($tableName . '.*')
+        $tableName = $this->query->getTable();
+        $table     = $this->pivot->getTable();
+        $query     = $this->query->field($tableName . '.*')
             ->field(true, false, $table, 'pivot', 'pivot__');
 
         if (empty($this->baseQuery)) {
+            $relationFk = $this->query->getPk();
             $query->join($table . ' pivot', 'pivot.' . $foreignKey . '=' . $tableName . '.' . $relationFk)
                 ->where($condition);
         }

--- a/library/think/model/relation/BelongsToMany.php
+++ b/library/think/model/relation/BelongsToMany.php
@@ -44,10 +44,11 @@ class BelongsToMany extends Relation
         $this->model      = $model;
         $this->foreignKey = $foreignKey;
         $this->localKey   = $localKey;
-        if (false === strpos($table, '\\')) {
-            $this->middle = $table;
-        } else {
+        if (false !== strpos($table, '\\')) {
             $this->pivotName = $table;
+            $this->middle    = basename(str_replace('\\', '/', $table));
+        } else {
+            $this->middle = $table;
         }
         $this->query = (new $model)->db();
         $this->pivot = $this->newPivot();

--- a/library/think/model/relation/HasMany.php
+++ b/library/think/model/relation/HasMany.php
@@ -183,7 +183,7 @@ class HasMany extends Relation
      * 保存（新增）当前关联数据对象
      * @access public
      * @param mixed $data 数据 可以使用数组 关联模型对象 和 关联对象的主键
-     * @return integer
+     * @return Model|false
      */
     public function save($data)
     {
@@ -191,9 +191,9 @@ class HasMany extends Relation
             $data = $data->getData();
         }
         // 保存关联表数据
-        $data[$this->foreignKey] = $this->parent->{$this->localKey};
         $model                   = new $this->model;
-        return $model->save($data);
+        $data[$this->foreignKey] = $this->parent->{$this->localKey};
+        return $model->save($data) ? $model : false;
     }
 
     /**

--- a/library/think/model/relation/HasMany.php
+++ b/library/think/model/relation/HasMany.php
@@ -11,7 +11,6 @@
 
 namespace think\model\relation;
 
-use think\Db;
 use think\db\Query;
 use think\Loader;
 use think\Model;
@@ -47,7 +46,14 @@ class HasMany extends Relation
         if ($closure) {
             call_user_func_array($closure, [ & $this->query]);
         }
-        return $this->relation($subRelation)->select();
+        $list   = $this->relation($subRelation)->select();
+        $parent = clone $this->parent;
+
+        foreach ($list as &$model) {
+            $model->setParent($parent);
+        }
+
+        return $list;
     }
 
     /**
@@ -84,6 +90,11 @@ class HasMany extends Relation
                 if (!isset($data[$result->$localKey])) {
                     $data[$result->$localKey] = [];
                 }
+
+                foreach ($data[$result->$localKey] as &$relationModel) {
+                    $relationModel->setParent(clone $result);
+                }
+
                 $result->setAttr($attr, $this->resultSetBuild($data[$result->$localKey]));
             }
         }
@@ -108,6 +119,11 @@ class HasMany extends Relation
             if (!isset($data[$result->$localKey])) {
                 $data[$result->$localKey] = [];
             }
+
+            foreach ($data[$result->$localKey] as &$relationModel) {
+                $relationModel->setParent(clone $result);
+            }
+
             $result->setAttr(Loader::parseName($relation), $this->resultSetBuild($data[$result->$localKey]));
         }
     }

--- a/library/think/model/relation/HasManyThrough.php
+++ b/library/think/model/relation/HasManyThrough.php
@@ -11,7 +11,6 @@
 
 namespace think\model\relation;
 
-use think\Db;
 use think\db\Query;
 use think\Exception;
 use think\Loader;
@@ -57,6 +56,7 @@ class HasManyThrough extends Relation
         if ($closure) {
             call_user_func_array($closure, [ & $this->query]);
         }
+
         return $this->relation($subRelation)->select();
     }
 
@@ -96,8 +96,7 @@ class HasManyThrough extends Relation
      * @return void
      */
     public function eagerlyResultSet(&$resultSet, $relation, $subRelation, $closure, $class)
-    {
-    }
+    {}
 
     /**
      * 预载入关联查询 返回模型对象
@@ -110,8 +109,7 @@ class HasManyThrough extends Relation
      * @return void
      */
     public function eagerlyResult(&$result, $relation, $subRelation, $closure, $class)
-    {
-    }
+    {}
 
     /**
      * 关联统计
@@ -121,8 +119,7 @@ class HasManyThrough extends Relation
      * @return integer
      */
     public function relationCount($result, $closure)
-    {
-    }
+    {}
 
     /**
      * 执行基础查询（进执行一次）

--- a/library/think/model/relation/MorphMany.php
+++ b/library/think/model/relation/MorphMany.php
@@ -215,7 +215,7 @@ class MorphMany extends Relation
      * 保存（新增）当前关联数据对象
      * @access public
      * @param mixed $data 数据 可以使用数组 关联模型对象 和 关联对象的主键
-     * @return integer
+     * @return Model|false
      */
     public function save($data)
     {
@@ -225,10 +225,10 @@ class MorphMany extends Relation
         // 保存关联表数据
         $pk = $this->parent->getPk();
 
+        $model                  = new $this->model;
         $data[$this->morphKey]  = $this->parent->$pk;
         $data[$this->morphType] = $this->type;
-        $model                  = new $this->model;
-        return $model->save($data);
+        return $model->save($data) ? $model : false;
     }
 
     /**

--- a/library/think/model/relation/MorphMany.php
+++ b/library/think/model/relation/MorphMany.php
@@ -11,7 +11,6 @@
 
 namespace think\model\relation;
 
-use think\Db;
 use think\db\Query;
 use think\Exception;
 use think\Loader;
@@ -56,7 +55,14 @@ class MorphMany extends Relation
         if ($closure) {
             call_user_func_array($closure, [ & $this->query]);
         }
-        return $this->relation($subRelation)->select();
+        $list   = $this->relation($subRelation)->select();
+        $parent = clone $this->parent;
+
+        foreach ($list as &$model) {
+            $model->setParent($parent);
+        }
+
+        return $list;
     }
 
     /**
@@ -119,6 +125,10 @@ class MorphMany extends Relation
                 if (!isset($data[$result->$pk])) {
                     $data[$result->$pk] = [];
                 }
+                foreach ($data[$result->$pk] as &$relationModel) {
+                    $relationModel->setParent(clone $result);
+                    $relationModel->isUpdate(true);
+                }
                 $result->setAttr($attr, $this->resultSetBuild($data[$result->$pk]));
             }
         }
@@ -141,6 +151,12 @@ class MorphMany extends Relation
                 $this->morphKey  => $result->$pk,
                 $this->morphType => $this->type,
             ], $relation, $subRelation, $closure);
+
+            foreach ($data[$result->$pk] as &$relationModel) {
+                $relationModel->setParent(clone $result);
+                $relationModel->isUpdate(true);
+            }
+
             $result->setAttr(Loader::parseName($relation), $this->resultSetBuild($data[$result->$pk]));
         }
     }

--- a/library/think/model/relation/MorphOne.php
+++ b/library/think/model/relation/MorphOne.php
@@ -1,0 +1,209 @@
+<?php
+// +----------------------------------------------------------------------
+// | ThinkPHP [ WE CAN DO IT JUST THINK ]
+// +----------------------------------------------------------------------
+// | Copyright (c) 2006~2017 http://thinkphp.cn All rights reserved.
+// +----------------------------------------------------------------------
+// | Licensed ( http://www.apache.org/licenses/LICENSE-2.0 )
+// +----------------------------------------------------------------------
+// | Author: liu21st <liu21st@gmail.com>
+// +----------------------------------------------------------------------
+
+namespace think\model\relation;
+
+use think\Db;
+use think\db\Query;
+use think\Exception;
+use think\Loader;
+use think\Model;
+use think\model\Relation;
+
+class MorphOne extends Relation
+{
+    // 多态字段
+    protected $morphKey;
+    protected $morphType;
+    // 多态类型
+    protected $type;
+
+    /**
+     * 构造函数
+     * @access public
+     * @param Model  $parent    上级模型对象
+     * @param string $model     模型名
+     * @param string $morphKey  关联外键
+     * @param string $morphType 多态字段名
+     * @param string $type      多态类型
+     */
+    public function __construct(Model $parent, $model, $morphKey, $morphType, $type)
+    {
+        $this->parent    = $parent;
+        $this->model     = $model;
+        $this->type      = $type;
+        $this->morphKey  = $morphKey;
+        $this->morphType = $morphType;
+        $this->query     = (new $model)->db();
+    }
+
+    /**
+     * 延迟获取关联数据
+     * @param string   $subRelation 子关联名
+     * @param \Closure $closure     闭包查询条件
+     * @return false|\PDOStatement|string|\think\Collection
+     */
+    public function getRelation($subRelation = '', $closure = null)
+    {
+        if ($closure) {
+            call_user_func_array($closure, [ & $this->query]);
+        }
+        return $this->relation($subRelation)->find();
+    }
+
+    /**
+     * 根据关联条件查询当前模型
+     * @access public
+     * @param string  $operator 比较操作符
+     * @param integer $count    个数
+     * @param string  $id       关联表的统计字段
+     * @param string  $joinType JOIN类型
+     * @return Query
+     */
+    public function has($operator = '>=', $count = 1, $id = '*', $joinType = 'INNER')
+    {
+        return $this->parent;
+    }
+
+    /**
+     * 根据关联条件查询当前模型
+     * @access public
+     * @param mixed $where 查询条件（数组或者闭包）
+     * @return Query
+     */
+    public function hasWhere($where = [])
+    {
+        throw new Exception('relation not support: hasWhere');
+    }
+
+    /**
+     * 预载入关联查询
+     * @access public
+     * @param array    $resultSet   数据集
+     * @param string   $relation    当前关联名
+     * @param string   $subRelation 子关联名
+     * @param \Closure $closure     闭包
+     * @return void
+     */
+    public function eagerlyResultSet(&$resultSet, $relation, $subRelation, $closure)
+    {
+        $morphType = $this->morphType;
+        $morphKey  = $this->morphKey;
+        $type      = $this->type;
+        $range     = [];
+        foreach ($resultSet as $result) {
+            $pk = $result->getPk();
+            // 获取关联外键列表
+            if (isset($result->$pk)) {
+                $range[] = $result->$pk;
+            }
+        }
+
+        if (!empty($range)) {
+            $data = $this->eagerlyMorphToOne([
+                $morphKey  => ['in', $range],
+                $morphType => $type,
+            ], $relation, $subRelation, $closure);
+            // 关联属性名
+            $attr = Loader::parseName($relation);
+            // 关联数据封装
+            foreach ($resultSet as $result) {
+                if (!isset($data[$result->$pk])) {
+                    $data[$result->$pk] = [];
+                }
+                $result->setAttr($attr, $this->resultSetBuild($data[$result->$pk]));
+            }
+        }
+    }
+
+    /**
+     * 预载入关联查询
+     * @access public
+     * @param Model    $result      数据对象
+     * @param string   $relation    当前关联名
+     * @param string   $subRelation 子关联名
+     * @param \Closure $closure     闭包
+     * @return void
+     */
+    public function eagerlyResult(&$result, $relation, $subRelation, $closure)
+    {
+        $pk = $result->getPk();
+        if (isset($result->$pk)) {
+            $data = $this->eagerlyMorphToOne([
+                $this->morphKey  => $result->$pk,
+                $this->morphType => $this->type,
+            ], $relation, $subRelation, $closure);
+            $result->setAttr(Loader::parseName($relation), $this->resultSetBuild($data[$result->$pk]));
+        }
+    }
+
+    /**
+     * 多态一对一 关联模型预查询
+     * @access   public
+     * @param array         $where       关联预查询条件
+     * @param string        $relation    关联名
+     * @param string        $subRelation 子关联
+     * @param bool|\Closure $closure     闭包
+     * @return array
+     */
+    protected function eagerlyMorphToOne($where, $relation, $subRelation = '', $closure = false)
+    {
+        // 预载入关联查询 支持嵌套预载入
+        if ($closure) {
+            call_user_func_array($closure, [ & $this]);
+        }
+        $list     = $this->query->where($where)->with($subRelation)->find();
+        $morphKey = $this->morphKey;
+        // 组装模型数据
+        $data = [];
+        foreach ($list as $set) {
+            $data[$set->$morphKey][] = $set;
+        }
+        return $data;
+    }
+
+    /**
+     * 保存（新增）当前关联数据对象
+     * @access public
+     * @param mixed $data 数据 可以使用数组 关联模型对象 和 关联对象的主键
+     * @return Model|false
+     */
+    public function save($data)
+    {
+        if ($data instanceof Model) {
+            $data = $data->getData();
+        }
+        // 保存关联表数据
+        $pk = $this->parent->getPk();
+
+        $model                  = new $this->model;
+        $data[$this->morphKey]  = $this->parent->$pk;
+        $data[$this->morphType] = $this->type;
+        return $model->save($data) ? $model : false;
+    }
+
+    /**
+     * 执行基础查询（进执行一次）
+     * @access protected
+     * @return void
+     */
+    protected function baseQuery()
+    {
+        if (empty($this->baseQuery)) {
+            $pk                    = $this->parent->getPk();
+            $map[$this->morphKey]  = $this->parent->$pk;
+            $map[$this->morphType] = $this->type;
+            $this->query->where($map);
+            $this->baseQuery = true;
+        }
+    }
+
+}

--- a/library/think/model/relation/MorphTo.php
+++ b/library/think/model/relation/MorphTo.php
@@ -241,7 +241,7 @@ class MorphTo extends Relation
         $this->parent->setAttr($morphType, get_class($model));
         $this->parent->save();
 
-        return $this->parent->setAttr($this->relation, $model);
+        return $this->parent->data($this->relation, $model);
     }
 
     /**
@@ -258,7 +258,7 @@ class MorphTo extends Relation
         $this->parent->setAttr($morphType, null);
         $this->parent->save();
 
-        return $this->parent->setAttr($this->relation, null);
+        return $this->parent->data($this->relation, null);
     }
 
     /**

--- a/library/think/model/relation/MorphTo.php
+++ b/library/think/model/relation/MorphTo.php
@@ -34,7 +34,7 @@ class MorphTo extends Relation
      * @param array  $alias     多态别名定义
      * @param string $relation  关联名
      */
-    public function __construct(Model $parent, $morphType, $morphKey, $alias = [], $relation)
+    public function __construct(Model $parent, $morphType, $morphKey, $alias = [], $relation = null)
     {
         $this->parent    = $parent;
         $this->morphType = $morphType;

--- a/library/think/model/relation/MorphTo.php
+++ b/library/think/model/relation/MorphTo.php
@@ -23,6 +23,7 @@ class MorphTo extends Relation
     protected $morphType;
     // 多态别名
     protected $alias;
+    protected $relation;
 
     /**
      * 构造函数
@@ -31,13 +32,15 @@ class MorphTo extends Relation
      * @param string $morphType 多态字段名
      * @param string $morphKey  外键名
      * @param array  $alias     多态别名定义
+     * @param string $relation  关联名
      */
-    public function __construct(Model $parent, $morphType, $morphKey, $alias = [])
+    public function __construct(Model $parent, $morphType, $morphKey, $alias = [], $relation)
     {
         $this->parent    = $parent;
         $this->morphType = $morphType;
         $this->morphKey  = $morphKey;
         $this->alias     = $alias;
+        $this->relation  = $relation;
     }
 
     /**
@@ -237,13 +240,13 @@ class MorphTo extends Relation
         $this->parent->setAttr($morphKey, $model->$pk);
         $this->parent->setAttr($morphType, get_class($model));
         $this->parent->save();
-        return $this;
+
+        return $this->parent->setAttr($this->relation, $model);
     }
 
     /**
-     * 添加关联数据
+     * 注销关联数据
      * @access public
-     * @param Model $model       关联模型对象
      * @return Model
      */
     public function dissociate()
@@ -254,7 +257,8 @@ class MorphTo extends Relation
         $this->parent->setAttr($morphKey, null);
         $this->parent->setAttr($morphType, null);
         $this->parent->save();
-        return $this;
+
+        return $this->parent->setAttr($this->relation, null);
     }
 
     /**

--- a/library/think/model/relation/MorphTo.php
+++ b/library/think/model/relation/MorphTo.php
@@ -223,6 +223,41 @@ class MorphTo extends Relation
     }
 
     /**
+     * 添加关联数据
+     * @access public
+     * @param Model $model       关联模型对象
+     * @return Model
+     */
+    public function associate($model)
+    {
+        $morphKey  = $this->morphKey;
+        $morphType = $this->morphType;
+        $pk        = $model->getPk();
+
+        $this->parent->setAttr($morphKey, $model->$pk);
+        $this->parent->setAttr($morphType, get_class($model));
+        $this->parent->save();
+        return $this;
+    }
+
+    /**
+     * 添加关联数据
+     * @access public
+     * @param Model $model       关联模型对象
+     * @return Model
+     */
+    public function dissociate()
+    {
+        $morphKey  = $this->morphKey;
+        $morphType = $this->morphType;
+
+        $this->parent->setAttr($morphKey, null);
+        $this->parent->setAttr($morphType, null);
+        $this->parent->save();
+        return $this;
+    }
+
+    /**
      * 执行基础查询（进执行一次）
      * @access protected
      * @return void

--- a/library/think/model/relation/MorphTo.php
+++ b/library/think/model/relation/MorphTo.php
@@ -56,8 +56,13 @@ class MorphTo extends Relation
         // 多态模型
         $model = $this->parseModel($this->parent->$morphType);
         // 主键数据
-        $pk = $this->parent->$morphKey;
-        return (new $model)->relation($subRelation)->find($pk);
+        $pk            = $this->parent->$morphKey;
+        $relationModel = (new $model)->relation($subRelation)->find($pk);
+
+        if ($relationModel) {
+            $relationModel->setParent(clone $this->parent);
+        }
+        return $relationModel;
     }
 
     /**
@@ -168,7 +173,11 @@ class MorphTo extends Relation
                         if (!isset($data[$result->$morphKey])) {
                             throw new Exception('relation data not exists :' . $this->model);
                         } else {
-                            $result->setAttr($attr, $data[$result->$morphKey]);
+                            $relationModel = $data[$result->$morphKey];
+                            $relationModel->setParent(clone $result);
+                            $relationModel->isUpdate(true);
+
+                            $result->setAttr($attr, $relationModel);
                         }
                     }
                 }
@@ -220,6 +229,7 @@ class MorphTo extends Relation
         $pk   = $this->parent->{$this->morphKey};
         $data = (new $model)->with($subRelation)->find($pk);
         if ($data) {
+            $data->setParent(clone $result);
             $data->isUpdate(true);
         }
         $result->setAttr(Loader::parseName($relation), $data ?: null);

--- a/library/think/model/relation/OneToOne.php
+++ b/library/think/model/relation/OneToOne.php
@@ -162,17 +162,17 @@ abstract class OneToOne extends Relation
      * 保存（新增）当前关联数据对象
      * @access public
      * @param mixed $data 数据 可以使用数组 关联模型对象 和 关联对象的主键
-     * @return integer
+     * @return Model|false
      */
     public function save($data)
     {
         if ($data instanceof Model) {
             $data = $data->getData();
         }
+        $model = new $this->model;
         // 保存关联表数据
         $data[$this->foreignKey] = $this->parent->{$this->localKey};
-        $model                   = new $this->model;
-        return $model->save($data);
+        return $model->save($data) ? $model : false;
     }
 
     /**

--- a/library/think/model/relation/OneToOne.php
+++ b/library/think/model/relation/OneToOne.php
@@ -245,13 +245,19 @@ abstract class OneToOne extends Relation
                 }
             }
         }
+
         if (isset($list[$relation])) {
             $relationModel = new $model($list[$relation]);
+            $relationModel->setParent(clone $result);
+            $relationModel->isUpdate(true);
+
             if (!empty($this->bindAttr)) {
                 $this->bindAttr($relationModel, $result, $this->bindAttr);
             }
+        } else {
+            $relationModel = null;
         }
-        $result->setAttr(Loader::parseName($relation), !isset($relationModel) ? null : $relationModel->isUpdate(true));
+        $result->setAttr(Loader::parseName($relation), $relationModel);
     }
 
     /**

--- a/library/think/model/relation/OneToOne.php
+++ b/library/think/model/relation/OneToOne.php
@@ -30,6 +30,8 @@ abstract class OneToOne extends Relation
     protected $joinType;
     // 要绑定的属性
     protected $bindAttr = [];
+    // 关联方法名
+    protected $relation;
 
     /**
      * 设置join类型

--- a/library/traits/model/SoftDelete.php
+++ b/library/traits/model/SoftDelete.php
@@ -30,7 +30,7 @@ trait SoftDelete
     {
         $model = new static();
         $field = $model->getDeleteTimeField(true);
-        return $model->db(false);
+        return $model->getQuery();
     }
 
     /**
@@ -42,7 +42,7 @@ trait SoftDelete
     {
         $model = new static();
         $field = $model->getDeleteTimeField(true);
-        return $model->db(false)
+        return $model->getQuery()
             ->useSoftDelete($field, ['not null', '']);
     }
 
@@ -64,7 +64,7 @@ trait SoftDelete
             $this->data[$name] = $this->autoWriteTimestamp($name);
             $result            = $this->isUpdate()->save();
         } else {
-            $result = $this->db(false)->delete($this->data);
+            $result = $this->getQuery()->delete($this->data);
         }
 
         $this->trigger('after_delete', $this);
@@ -117,7 +117,7 @@ trait SoftDelete
             $where[$pk] = $this->getData($pk);
         }
         // 恢复删除
-        return $this->db(false)
+        return $this->getQuery()
             ->useSoftDelete($name, ['not null', ''])
             ->where($where)
             ->update([$name => null]);

--- a/library/traits/model/SoftDelete.php
+++ b/library/traits/model/SoftDelete.php
@@ -42,7 +42,8 @@ trait SoftDelete
     {
         $model = new static();
         $field = $model->getDeleteTimeField(true);
-        return $model->db(false)->useSoftDelete($field, ['not null', '']);
+        return $model->db(false)
+            ->useSoftDelete($field, ['not null', '']);
     }
 
     /**
@@ -116,7 +117,10 @@ trait SoftDelete
             $where[$pk] = $this->getData($pk);
         }
         // 恢复删除
-        return $this->db(false)->useSoftDelete($name, ['not null', ''])->where($where)->update([$name => null]);
+        return $this->db(false)
+            ->useSoftDelete($name, ['not null', ''])
+            ->where($where)
+            ->update([$name => null]);
     }
 
     /**

--- a/library/traits/model/SoftDelete.php
+++ b/library/traits/model/SoftDelete.php
@@ -30,7 +30,7 @@ trait SoftDelete
     {
         $model = new static();
         $field = $model->getDeleteTimeField(true);
-        return $model->db(false)->removeWhereField($field);
+        return $model->db(false);
     }
 
     /**
@@ -42,7 +42,7 @@ trait SoftDelete
     {
         $model = new static();
         $field = $model->getDeleteTimeField(true);
-        return $model->db(false)->whereNotNull($field);
+        return $model->db(false)->useSoftDelete($field, ['not null', '']);
     }
 
     /**
@@ -112,12 +112,11 @@ trait SoftDelete
     {
         $name = $this->getDeleteTimeField();
         if (empty($where)) {
-            $pk           = $this->getPk();
-            $where[$pk]   = $this->getData($pk);
-            $where[$name] = ['not null', ''];
+            $pk         = $this->getPk();
+            $where[$pk] = $this->getData($pk);
         }
         // 恢复删除
-        return $this->db(false)->removeWhereField($this->getDeleteTimeField(true))->where($where)->update([$name => null]);
+        return $this->db(false)->useSoftDelete($name, ['not null', ''])->where($where)->update([$name => null]);
     }
 
     /**
@@ -129,7 +128,7 @@ trait SoftDelete
     protected function base($query)
     {
         $field = $this->getDeleteTimeField(true);
-        $query->whereNull($field);
+        $query->useSoftDelete($field);
     }
 
     /**

--- a/tests/application/config.php
+++ b/tests/application/config.php
@@ -13,7 +13,7 @@
 return [
     'url_route_on' => true,
     'log'          => [
-        'type' => 'trace', // 支持 socket trace file
+        'type' => 'file', // 支持 socket trace file
     ],
     'view'         => [
         // 模板引擎

--- a/tests/thinkphp/library/think/log/driver/fileTest.php
+++ b/tests/thinkphp/library/think/log/driver/fileTest.php
@@ -29,6 +29,6 @@ class fileTest extends \PHPUnit_Framework_TestCase
         Log::record($record_msg, 'notice');
         $logs = Log::getLog();
 
-        $this->assertEquals([], $logs));
+        $this->assertEquals([], $logs);
     }
 }

--- a/tests/thinkphp/library/think/log/driver/fileTest.php
+++ b/tests/thinkphp/library/think/log/driver/fileTest.php
@@ -29,6 +29,6 @@ class fileTest extends \PHPUnit_Framework_TestCase
         Log::record($record_msg, 'notice');
         $logs = Log::getLog();
 
-        $this->assertNotFalse(array_search($record_msg, $logs['notice']));
+        $this->assertEquals([], $logs));
     }
 }

--- a/tests/thinkphp/library/think/logTest.php
+++ b/tests/thinkphp/library/think/logTest.php
@@ -20,18 +20,6 @@ use think\Log;
 class logTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function testRecord()
-    {
-        Log::clear();
-        Log::record('test');
-        $this->assertEquals(['log' => ['test']], Log::getLog());
-        Log::record('hello', 'info');
-        $this->assertEquals(['log' => ['test'], 'info' => ['hello']], Log::getLog());
-        Log::clear();
-        Log::info('test');
-        $this->assertEquals(['info' => ['test']], Log::getLog());
-    }
-
     public function testSave()
     {
         Log::init(['type' => 'test']);

--- a/tests/thinkphp/library/think/requestTest.php
+++ b/tests/thinkphp/library/think/requestTest.php
@@ -17,7 +17,6 @@ namespace tests\thinkphp\library\think;
 
 use think\Config;
 use think\Request;
-use think\Route;
 
 class requestTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/thinkphp/library/think/routeTest.php
+++ b/tests/thinkphp/library/think/routeTest.php
@@ -40,7 +40,7 @@ class routeTest extends \PHPUnit_Framework_TestCase
         Route::any('user/:id', 'index/user');
         $result = Route::check($request, 'hello/thinkphp');
         $this->assertEquals([null, 'index', 'hello'], $result['module']);
-        $this->assertEquals(['user/:id' => true, 'hello/:name' => ['rule' => 'hello/:name', 'route' => 'index/hello', 'var' => ['name' => 1], 'option' => [], 'pattern' => []]], Route::rules('GET'));
+        $this->assertEquals(['hello' => true, 'user/:id' => true, 'hello/:name' => ['rule' => 'hello/:name', 'route' => 'index/hello', 'var' => ['name' => 1], 'option' => [], 'pattern' => []]], Route::rules('GET'));
         Route::rule('type1/:name', 'index/type', 'PUT|POST');
         Route::rule(['type2/:name' => 'index/type1']);
         Route::rule([['type3/:name', 'index/type2', ['method' => 'POST']]]);

--- a/tests/thinkphp/library/think/routeTest.php
+++ b/tests/thinkphp/library/think/routeTest.php
@@ -40,7 +40,7 @@ class routeTest extends \PHPUnit_Framework_TestCase
         Route::any('user/:id', 'index/user');
         $result = Route::check($request, 'hello/thinkphp');
         $this->assertEquals([null, 'index', 'hello'], $result['module']);
-        $this->assertEquals(['hello' => true, 'user/:id' => true, 'hello/:name' => ['rule' => 'hello/:name', 'route' => 'index/hello', 'var' => ['name' => 1], 'option' => [], 'pattern' => []]], Route::rules('GET'));
+        $this->assertEquals(['user/:id' => true, 'hello/:name' => ['rule' => 'hello/:name', 'route' => 'index/hello', 'var' => ['name' => 1], 'option' => [], 'pattern' => []]], Route::rules('GET'));
         Route::rule('type1/:name', 'index/type', 'PUT|POST');
         Route::rule(['type2/:name' => 'index/type1']);
         Route::rule([['type3/:name', 'index/type2', ['method' => 'POST']]]);
@@ -257,10 +257,10 @@ class routeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['index', 'blog', 'test'], $result['module']);
 
         Route::bind('\app\index\controller', 'namespace');
-        $this->assertEquals(['type' => 'method', 'method' => ['\app\index\controller\Blog', 'read']], Route::check($request, 'blog/read'));
+        $this->assertEquals(['type' => 'method', 'method' => ['\app\index\controller\Blog', 'read'], 'var' => []], Route::check($request, 'blog/read'));
 
         Route::bind('\app\index\controller\Blog', 'class');
-        $this->assertEquals(['type' => 'method', 'method' => ['\app\index\controller\Blog', 'read']], Route::check($request, 'read'));
+        $this->assertEquals(['type' => 'method', 'method' => ['\app\index\controller\Blog', 'read'], 'var' => []], Route::check($request, 'read'));
     }
 
     public function testDomain()

--- a/tests/thinkphp/library/think/templateTest.php
+++ b/tests/thinkphp/library/think/templateTest.php
@@ -240,7 +240,7 @@ EOF;
 <#\$info.a|default='test'?'yes':'no'#>
 EOF;
         $data = <<<EOF
-<?php echo ((is_array(\$info)?\$info['a']:\$info->a) ?:'test')?'yes':'no'; ?>
+<?php echo ((is_array(\$info)?\$info['a']:\$info->a) ?: 'test')?'yes':'no'; ?>
 EOF;
         $template->parse($content);
         $this->assertEquals($data, $content);

--- a/tests/thinkphp/library/think/templateTest.php
+++ b/tests/thinkphp/library/think/templateTest.php
@@ -240,7 +240,7 @@ EOF;
 <#\$info.a|default='test'?'yes':'no'#>
 EOF;
         $data = <<<EOF
-<?php echo ((is_array(\$info)?\$info['a']:\$info->a) !== ''?(is_array(\$info)?\$info['a']:\$info->a):'test')?'yes':'no'; ?>
+<?php echo ((is_array(\$info)?\$info['a']:\$info->a) ?:'test')?'yes':'no'; ?>
 EOF;
         $template->parse($content);
         $this->assertEquals($data, $content);


### PR DESCRIPTION
详细介绍：https://hanxv.cn/archives/89.html

1.取消cookie存入语言设置功能

客户端在中文语言环境下调接口，tp将语言设置存入cookie。此后，修改系统语言为英文，再次调接口，因为此时tp是调用的cookie中的语言设置，所以依然是中文，即客户端不能即时的修改语言。

2.增加Accept-Language 转义功能

ios客户端从ios系统中拿到的中文语言环境变量是zh-hans-us,原有的detect()方法不能将其转义为zh-ch。

增加Accept-Language 转义功能，可以手动设置请求头对应的语言包，原有的zh-hans-cn的转义作为默认转义，放置在self::$acceptLanguage变量中
