### PR TITLE
多语言功能改进

### DIFF
--- a/library/think/Lang.php
+++ b/library/think/Lang.php
@@ -25,6 +25,8 @@ class Lang
     protected static $langCookieExpire = 3600;
     // 允许语言列表
     protected static $allowLangList = [];
+    //Accept-Language转义为对应的语言包 系统默认设置
+    private static $acceptLanguage = ['zh-hans-cn'=>'zh-cn'];
 
     // 设定当前的语言
     public static function range($range = '')
@@ -34,6 +36,7 @@ class Lang
         } else {
             self::$range = $range;
         }
+        return self::$range;
     }
 
     /**
@@ -93,7 +96,6 @@ class Lang
     /**
      * 获取语言定义(不区分大小写)
      * @param string|null   $name 语言变量
-     * @param array         $vars 变量替换
      * @param string        $range 语言作用域
      * @return mixed
      */
@@ -152,25 +154,25 @@ class Lang
     {
         // 自动侦测设置获取语言选择
         $langSet = '';
+
         if (isset($_GET[self::$langDetectVar])) {
             // url中设置了语言变量
             $langSet = strtolower($_GET[self::$langDetectVar]);
-            Cookie::set(self::$langCookieVar, $langSet, self::$langCookieExpire);
-        } elseif (Cookie::get(self::$langCookieVar)) {
-            // 获取上次用户的选择
-            $langSet = strtolower(Cookie::get(self::$langCookieVar));
-        } elseif (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+        }
+        elseif (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
             // 自动侦测浏览器语言
             preg_match('/^([a-z\d\-]+)/i', $_SERVER['HTTP_ACCEPT_LANGUAGE'], $matches);
             $langSet = strtolower($matches[1]);
-            Cookie::set(self::$langCookieVar, $langSet, self::$langCookieExpire);
+            $header_accept_lang_config = Config::get('header_accept_lang');
+            if(isset($header_accept_lang_config[$langSet])){
+                $langSet =$header_accept_lang_config[$langSet];
+            }elseif(isset(self::$acceptLanguage[$langSet])){
+                $langSet =self::$acceptLanguage[$langSet];
+            }
         }
         if (empty(self::$allowLangList) || in_array($langSet, self::$allowLangList)) {
             // 合法的语言
             self::$range = $langSet ?: self::$range;
-        }
-        if ('zh-hans-cn' == self::$range) {
-            self::$range = 'zh-cn';
         }
         return self::$range;
     }


### PR DESCRIPTION
详细介绍：https://hanxv.cn/archives/89.html

1.取消cookie存入语言设置功能

客户端在中文语言环境下调接口，tp将语言设置存入cookie。此后，修改系统语言为英文，再次调接口，因为此时tp是调用的cookie中的语言设置，所以依然是中文，即客户端不能即时的修改语言。

2.增加Accept-Language 转义功能

ios客户端从ios系统中拿到的中文语言环境变量是zh-hans-us,原有的detect()方法不能将其转义为zh-ch。

增加Accept-Language 转义功能，可以手动设置请求头对应的语言包，原有的zh-hans-cn的转义作为默认转义，放置在self::$acceptLanguage变量中
