### PR TITLE
think命令因公共配置文件报异常

### DIFF
--- a/library/think/App.php
+++ b/library/think/App.php
@@ -508,10 +508,11 @@ class App
             }
 
             // 加载公共文件
-            if (is_file($path . 'common' . EXT)) {
-                include $path . 'common' . EXT;
+            if(!IS_CLI) {
+                if (is_file($path . 'common' . EXT)) {
+                    include $path . 'common' . EXT;
+                }
             }
-
             // 加载当前模块语言包
             if ($module) {
                 Lang::load($path . 'lang' . DS . Request::instance()->langset() . EXT);


### PR DESCRIPTION
think命令默认加载公共配置文件,这样会导致在公共配置文件里面定义的常量如果使用了$_SERVER['HTTP_HOST']这样的变量,会报如下异常

  [think\exception\ErrorException]
  Undefined index: HTTP_HOST

所以加载公共配置文件前判断下是不是在命令行模式