### PR TITLE
关于语言包的加载

### DIFF
--- a/base.php
+++ b/base.php
@@ -29,6 +29,7 @@ defined('TEMP_PATH') or define('TEMP_PATH', RUNTIME_PATH . 'temp' . DS);
 defined('CONF_PATH') or define('CONF_PATH', APP_PATH); // 配置文件目录
 defined('CONF_EXT') or define('CONF_EXT', EXT); // 配置文件后缀
 defined('ENV_PREFIX') or define('ENV_PREFIX', 'PHP_'); // 环境变量的配置前缀
+defined('LANG_PATH') or define('LANG_PATH', APP_PATH); // 多语言配置文件目录
 
 // 环境常量
 define('IS_CLI', PHP_SAPI == 'cli' ? true : false);

--- a/library/think/App.php
+++ b/library/think/App.php
@@ -97,6 +97,7 @@ class App
             Lang::load([
                 THINK_PATH . 'lang' . DS . $request->langset() . EXT,
                 APP_PATH . 'lang' . DS . $request->langset() . EXT,
+                LANG_PATH . 'lang' . DS . $request->langset() . EXT,
             ]);
 
             // 获取应用调度信息

--- a/library/think/Log.php
+++ b/library/think/Log.php
@@ -158,7 +158,7 @@ class Log
             if ($result) {
                 self::$log = [];
             }
-
+            Hook::listen('log_write_done',$log);
             return $result;
         }
         return true;


### PR DESCRIPTION
1.增加LANG_PATH全局变量
2.增加加载LANG_PATH目录下的语言包

变动原因：
在有两个应用的情况下，一个应用命名为admin，另一个应用为api。
通过在入口文件定义CONF_PATH，可以实现共享配置文件，但是语言包不能共享。
如果增加LANG_PATH定义语言包目录的话，就可以自主定义语言包位置，实现多应用共享语言包。