### PR TITLE
修正join其他表时生成的delete语句错误。

### DIFF
--- a/library/think/db/builder/Sqlsrv.php
+++ b/library/think/db/builder/Sqlsrv.php
@@ -21,7 +21,7 @@ class Sqlsrv extends Builder
     protected $selectSql       = 'SELECT T1.* FROM (SELECT thinkphp.*, ROW_NUMBER() OVER (%ORDER%) AS ROW_NUMBER FROM (SELECT %DISTINCT% %FIELD% FROM %TABLE%%JOIN%%WHERE%%GROUP%%HAVING%) AS thinkphp) AS T1 %LIMIT%%COMMENT%';
     protected $selectInsertSql = 'SELECT %DISTINCT% %FIELD% FROM %TABLE%%JOIN%%WHERE%%GROUP%%HAVING%';
     protected $updateSql       = 'UPDATE %TABLE% SET %SET% FROM %TABLE% %JOIN% %WHERE% %LIMIT% %LOCK%%COMMENT%';
-    protected $deleteSql       = 'DELETE FROM %TABLE% %USING% %JOIN% %WHERE% %LIMIT% %LOCK%%COMMENT%';
+    protected $deleteSql       = 'DELETE FROM %TABLE%  %USING% FROM %TABLE%  %JOIN% %WHERE% %LIMIT% %LOCK%%COMMENT%';
 
     /**
      * order分析


### PR DESCRIPTION
Db::table('a')->join('b','a.map=b.id')
            ->where('b.id=1')->delete();
生成的语句是
delete from a inner join b on a.map=b.id where b.id=1 //这在mssql中存在语法错误！
正确的语句应该是delete from a  from a inner join b on a.map=b.id where b.id=1 
希望采纳！