### PR TITLE
修复配置extra目录临时文件名中含CONF_EXT(如 vi 的 .swp 文件)被错误加载导致报错的问题

### DIFF
--- a/library/think/App.php
+++ b/library/think/App.php
@@ -492,7 +492,7 @@ class App
                 $dir   = CONF_PATH . $module . 'extra';
                 $files = scandir($dir);
                 foreach ($files as $file) {
-                    if (strpos($file, CONF_EXT)) {
+                    if (pathinfo($file, PATHINFO_EXTENSION) === CONF_EXT) {
                         $filename = $dir . DS . $file;
                         Config::load($filename, pathinfo($file, PATHINFO_FILENAME));
                     }


### PR DESCRIPTION
之前的代码逻辑中，如果配置扩展目录（ `CONF_PATH . $module . 'extra'` ）中有一个文件名中包含 `CONF_EXT` 字符串，但不是以 `CONF_EXT` 结尾，也会被自动加载。
修改为判断只有文件名以 `CONF_EXT` 结尾的情况，才会被自动加载。

e.g.
比如配置文件 `app.php`, 使用 vi 打开时会生成 `.app.php.swp` 临时文件。 APP::init() 内的逻辑会自动调 CONFIG::load, 但是 CONFIG::parse() 中发现没有 `\think\config\driver\swp` 类而报错。


