### PR TITLE
library/think/Log.php 161行添加log存储完成行为监听

### DIFF
--- a/library/think/Log.php
+++ b/library/think/Log.php
@@ -158,7 +158,7 @@ class Log
             if ($result) {
                 self::$log = [];
             }
-
+            Hook::listen('log_write_done',$log);
             return $result;
         }
         return true;


### PR DESCRIPTION
我在进行多进程异步通信操作时，需要回收子进程，但是又不要影响日志输出，试了官方给出各个行为监听，都会中断log输出。我希望在这里加一个log存储完成的行为监听，这样就可以在log存储完成后，进行子进程回收工作。