### PR TITLE
修复 传入数组批量设置数据表以及别名 bug

### DIFF
--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -199,7 +199,7 @@ abstract class Builder
                     $key = strstr($key, '@think', true);
                 }
                 $key    = $this->parseSqlTable($key);
-                $item[] = $this->parseKey($key) . ' ' . $this->parseKey($table);
+                $item[] = $this->parseKey($key) . ' ' . (isset($options['alias'][$table]) ? $this->parseKey($options['alias'][$table]) : $this->parseKey($table));
             } else {
                 $table = $this->parseSqlTable($table);
                 if (isset($options['alias'][$table])) {


### PR DESCRIPTION
Db::table('think_user')->alias(['think_user'=>'user','think_dept'=>'dept'])->join('think_dept','dept.user_id= user.id')->select();
生成的SQL为 
SELECT * FROM think_user user INNER JOIN think_dept think_dept ON dept.user_id= user.id
修改后生成的SQL为 
SELECT * FROM think_user user INNER JOIN think_dept dept ON dept.user_id= user.id