### PR TITLE
增加clear方法

### DIFF
--- a/library/think/Db.php
+++ b/library/think/Db.php
@@ -89,7 +89,7 @@ class Db
         return self::$instance[$name];
     }
     
-    public static function clear(){
+    public static function clear() {
         self::$instance = null;
     }
 

--- a/library/think/Db.php
+++ b/library/think/Db.php
@@ -88,6 +88,10 @@ class Db
         }
         return self::$instance[$name];
     }
+    
+    public static function clear(){
+        self::$instance = null;
+    }
 
     /**
      * 数据库连接参数解析


### PR DESCRIPTION
在进行异步多进程操作时，当父进程初始化了Db类之后，异步出的子进程继续使用Db类进行数据库操作，会出现broken pipe或者mysql has gone away等异常错误。
而在创建子进程之前，清空Db类，则可以避免该错误发生。所以建议在Db类中增加clear函数方法，进行Db类的清空操作。