### PR TITLE
修复当设置数据库断线重连后，当断线后执行启动事务startTrans不会进行重连

### DIFF
--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -647,7 +647,7 @@ abstract class Connection
                 return $this->close()->startTrans();
             }
             throw $e;
-        } catch (\Exception $e){ 
+        } catch (\Exception $e){
             if ($this->isBreak($e)) {
                 return $this->close()->startTrans();
             }

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -642,7 +642,12 @@ abstract class Connection
                 return $this->close()->startTrans();
             }
             throw $e;
-        } catch (\Exception $e){
+        } catch (\ErrorException $e) {
+            if ($this->isBreak($e)) {
+                return $this->close()->startTrans();
+            }
+            throw $e;
+        }catch (\Exception $e){
             if ($this->isBreak($e)) {
                 return $this->close()->startTrans();
             }

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -647,7 +647,7 @@ abstract class Connection
                 return $this->close()->startTrans();
             }
             throw $e;
-        }catch (\Exception $e){
+        } catch (\Exception $e){
             if ($this->isBreak($e)) {
                 return $this->close()->startTrans();
             }

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -637,16 +637,6 @@ abstract class Connection
                 );
             }
 
-        } catch (\PDOException $e) {
-            if ($this->isBreak($e)) {
-                return $this->close()->startTrans();
-            }
-            throw $e;
-        } catch (\ErrorException $e) {
-            if ($this->isBreak($e)) {
-                return $this->close()->startTrans();
-            }
-            throw $e;
         } catch (\Exception $e){
             if ($this->isBreak($e)) {
                 return $this->close()->startTrans();

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -647,6 +647,11 @@ abstract class Connection
                 return $this->close()->startTrans();
             }
             throw $e;
+        } catch (\Exception $e){
+            if ($this->isBreak($e)) {
+                return $this->close()->startTrans();
+            }
+            throw $e;
         }
     }
 

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -637,6 +637,16 @@ abstract class Connection
                 );
             }
 
+        } catch (\PDOException $e) {
+            if ($this->isBreak($e)) {
+                return $this->close()->startTrans();
+            }
+            throw $e;
+        } catch (\ErrorException $e) {
+            if ($this->isBreak($e)) {
+                return $this->close()->startTrans();
+            }
+            throw $e;
         } catch (\Exception $e){
             if ($this->isBreak($e)) {
                 return $this->close()->startTrans();

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -642,7 +642,7 @@ abstract class Connection
                 return $this->close()->startTrans();
             }
             throw $e;
-        } catch (\ErrorException $e) {
+        } catch (\Exception $e){
             if ($this->isBreak($e)) {
                 return $this->close()->startTrans();
             }

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -649,7 +649,7 @@ abstract class Connection
             throw $e;
         } catch (\Exception $e){
             if ($this->isBreak($e)) {
-                return $this->close()->startTrans(); 
+                return $this->close()->startTrans();
             }
             throw $e;
         }

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -647,7 +647,7 @@ abstract class Connection
                 return $this->close()->startTrans();
             }
             throw $e;
-        } catch (\Exception $e){
+        } catch (\Exception $e){ 
             if ($this->isBreak($e)) {
                 return $this->close()->startTrans();
             }

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -647,11 +647,6 @@ abstract class Connection
                 return $this->close()->startTrans();
             }
             throw $e;
-        } catch (\Exception $e){
-            if ($this->isBreak($e)) {
-                return $this->close()->startTrans();
-            }
-            throw $e;
         }
     }
 

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -649,7 +649,7 @@ abstract class Connection
             throw $e;
         } catch (\Exception $e){
             if ($this->isBreak($e)) {
-                return $this->close()->startTrans();
+                return $this->close()->startTrans(); 
             }
             throw $e;
         }


### PR DESCRIPTION
设置database.php开启断线重连

```php
'break_reconnect' => true
```

假设mysql在连接10秒后断开与PDO的连接，并且断开后TP 5执行的第一次数据库操作为启动事务`startTrans`

此时TP 5框架还是不会进行断线重连，会抛出错误（think\exception\ErrorException）

当前的代码捕获不到这个错误，增加捕获`\Exception`后可以正常断线重连