### PR TITLE
修改代码中若干处错别字以及注释错误

### DIFF
--- a/library/think/Controller.php
+++ b/library/think/Controller.php
@@ -11,13 +11,14 @@
 
 namespace think;
 
-\think\Loader::import('controller/Jump', TRAIT_PATH, EXT);
-
 use think\exception\ValidateException;
+use traits\controller\Jump;
+
+Loader::import('controller/Jump', TRAIT_PATH, EXT);
 
 class Controller
 {
-    use \traits\controller\Jump;
+    use Jump;
 
     /**
      * @var \think\View 视图类实例

--- a/library/think/File.php
+++ b/library/think/File.php
@@ -95,7 +95,8 @@ class File extends SplFileObject
 
     /**
      * 获取文件的哈希散列值
-     * @return $string
+     * @param string $type
+     * @return mixed $string
      */
     public function hash($type = 'sha1')
     {

--- a/library/think/Lang.php
+++ b/library/think/Lang.php
@@ -64,7 +64,7 @@ class Lang
 
     /**
      * 加载语言定义(不区分大小写)
-     * @param string $file 语言文件
+     * @param array|string $file 语言文件
      * @param string $range 语言作用域
      * @return mixed
      */

--- a/library/think/Loader.php
+++ b/library/think/Loader.php
@@ -431,7 +431,7 @@ class Loader
      * @param string $layer        验证层名称
      * @param bool   $appendSuffix 是否添加类名后缀
      * @param string $common       公共模块名
-     * @return Object|false
+     * @return object|false
      * @throws ClassNotFoundException
      */
     public static function validate($name = '', $layer = 'validate', $appendSuffix = false, $common = 'common')

--- a/library/think/Loader.php
+++ b/library/think/Loader.php
@@ -360,7 +360,7 @@ class Loader
      * @param string $layer        业务层名称
      * @param bool   $appendSuffix 是否添加类名后缀
      * @param string $common       公共模块名
-     * @return Object
+     * @return object
      * @throws ClassNotFoundException
      */
     public static function model($name = '', $layer = 'model', $appendSuffix = false, $common = 'common')
@@ -400,7 +400,7 @@ class Loader
      * @param string $layer        控制层名称
      * @param bool   $appendSuffix 是否添加类名后缀
      * @param string $empty        空控制器名称
-     * @return Object
+     * @return object
      * @throws ClassNotFoundException
      */
     public static function controller($name, $layer = 'controller', $appendSuffix = false, $empty = '')

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -1669,7 +1669,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
      * 设置是否使用全局查询范围
      * @param bool $use 是否启用全局查询范围
      * @access public
-     * @return Model
+     * @return Query
      */
     public static function useGlobalScope($use)
     {

--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -11,6 +11,7 @@
 
 namespace think;
 
+use BadMethodCallException;
 use InvalidArgumentException;
 use think\db\Query;
 use think\exception\ValidateException;
@@ -567,6 +568,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
      * @access public
      * @param Relation        $modelRelation 模型关联对象
      * @return mixed
+     * @throws BadMethodCallException
      */
     protected function getRelationData(Relation $modelRelation)
     {
@@ -574,7 +576,11 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
             $value = $this->parent;
         } else {
             // 首先获取关联数据
-            $value = $modelRelation->getRelation();
+            if (method_exists($modelRelation, 'getRelation')) {
+                $value = $modelRelation->getRelation();
+            } else {
+                throw new BadMethodCallException('method not exists:' . get_class($modelRelation) . '-> getRelation');
+            }
         }
         return $value;
     }

--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -60,6 +60,11 @@ class Request
     protected $routeInfo = [];
 
     /**
+     * @var array 环境变量
+     */
+    protected $env;
+
+    /**
      * @var array 当前调度信息
      */
     protected $dispatch = [];

--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -1609,7 +1609,7 @@ class Request
     /**
      * 设置当前请求绑定的对象实例
      * @access public
-     * @param string $name 绑定的对象标识
+     * @param string|array $name 绑定的对象标识
      * @param mixed  $obj 绑定的对象实例
      * @return mixed
      */

--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -1546,7 +1546,7 @@ class Route
     /**
      * 解析URL地址中的参数Request对象
      * @access private
-     * @param string    $rule 路由规则
+     * @param string    $url 路由规则
      * @param array     $var 变量
      * @return void
      */

--- a/library/think/Template.php
+++ b/library/think/Template.php
@@ -59,6 +59,7 @@ class Template
     /**
      * 构造函数
      * @access public
+     * @param array $config
      */
     public function __construct(array $config = [])
     {

--- a/library/think/View.php
+++ b/library/think/View.php
@@ -127,7 +127,7 @@ class View
      * @access private
      * @param string|array  $name 参数名
      * @param mixed         $value 参数值
-     * @return void
+     * @return $this
      */
     public function config($name, $value = null)
     {

--- a/library/think/console/output/Descriptor.php
+++ b/library/think/console/output/Descriptor.php
@@ -69,7 +69,7 @@ class Descriptor
      * 描述参数
      * @param InputArgument $argument
      * @param array         $options
-     * @return string|mixed
+     * @return void
      */
     protected function describeInputArgument(InputArgument $argument, array $options = [])
     {
@@ -93,7 +93,7 @@ class Descriptor
      * 描述选项
      * @param InputOption $option
      * @param array       $options
-     * @return string|mixed
+     * @return void
      */
     protected function describeInputOption(InputOption $option, array $options = [])
     {
@@ -128,7 +128,7 @@ class Descriptor
      * 描述输入
      * @param InputDefinition $definition
      * @param array           $options
-     * @return string|mixed
+     * @return void
      */
     protected function describeInputDefinition(InputDefinition $definition, array $options = [])
     {
@@ -173,7 +173,7 @@ class Descriptor
      * 描述指令
      * @param Command $command
      * @param array   $options
-     * @return string|mixed
+     * @return void
      */
     protected function describeCommand(Command $command, array $options = [])
     {
@@ -208,7 +208,7 @@ class Descriptor
      * 描述控制台
      * @param Console $console
      * @param array   $options
-     * @return string|mixed
+     * @return void
      */
     protected function describeConsole(Console $console, array $options = [])
     {

--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -11,6 +11,7 @@
 
 namespace think\db;
 
+use BadMethodCallException;
 use PDO;
 use think\Exception;
 
@@ -46,7 +47,7 @@ abstract class Builder
     /**
      * 获取当前的连接对象实例
      * @access public
-     * @return void
+     * @return Connection
      */
     public function getConnection()
     {
@@ -56,7 +57,7 @@ abstract class Builder
     /**
      * 获取当前的Query对象实例
      * @access public
-     * @return void
+     * @return Query
      */
     public function getQuery()
     {
@@ -80,6 +81,7 @@ abstract class Builder
      * @param array     $data 数据
      * @param array     $options 查询参数
      * @return array
+     * @throws Exception
      */
     protected function parseData($data, $options)
     {
@@ -497,7 +499,7 @@ abstract class Builder
     /**
      * limit分析
      * @access protected
-     * @param mixed $lmit
+     * @param mixed $limit
      * @return string
      */
     protected function parseLimit($limit)
@@ -549,7 +551,11 @@ abstract class Builder
             foreach ($order as $key => $val) {
                 if (is_numeric($key)) {
                     if ('[rand]' == $val) {
-                        $array[] = $this->parseRand();
+                        if (method_exists($this, 'parseRand')) {
+                            $array[] = $this->parseRand();
+                        } else {
+                            throw new BadMethodCallException('method not exists:' . get_class($this) . '-> parseRand');
+                        }
                     } elseif (false === strpos($val, '(')) {
                         $array[] = $this->parseKey($val, $options);
                     } else {
@@ -654,7 +660,7 @@ abstract class Builder
     /**
      * 设置锁机制
      * @access protected
-     * @param bool $locl
+     * @param bool $lock
      * @return string
      */
     protected function parseLock($lock = false)
@@ -728,6 +734,7 @@ abstract class Builder
      * @param array     $options 表达式
      * @param bool      $replace 是否replace
      * @return string
+     * @throws Exception
      */
     public function insertAll($dataSet, $options = [], $replace = false)
     {
@@ -775,7 +782,7 @@ abstract class Builder
     }
 
     /**
-     * 生成slectinsert SQL
+     * 生成select insert SQL
      * @access public
      * @param array     $fields 数据
      * @param string    $table 数据表
@@ -796,7 +803,7 @@ abstract class Builder
     /**
      * 生成update SQL
      * @access public
-     * @param array     $fields 数据
+     * @param array     $data 数据
      * @param array     $options 表达式
      * @return string
      */

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -338,8 +338,8 @@ abstract class Connection
      * @param bool          $master 是否在主服务器读操作
      * @param bool          $pdo 是否返回PDO对象
      * @return mixed
-     * @throws BindParamException
      * @throws PDOException
+     * @throws \Exception
      */
     public function query($sql, $bind = [], $master = false, $pdo = false)
     {
@@ -400,8 +400,8 @@ abstract class Connection
      * @param string        $sql sql指令
      * @param array         $bind 参数绑定
      * @return int
-     * @throws BindParamException
      * @throws PDOException
+     * @throws \Exception
      */
     public function execute($sql, $bind = [])
     {
@@ -552,7 +552,7 @@ abstract class Connection
      * @access protected
      * @param bool   $pdo 是否返回PDOStatement
      * @param bool   $procedure 是否存储过程
-     * @return array
+     * @return PDOStatement|array
      */
     protected function getResult($pdo = false, $procedure = false)
     {
@@ -618,7 +618,8 @@ abstract class Connection
     /**
      * 启动事务
      * @access public
-     * @return void
+     * @return bool|mixed
+     * @throws \Exception
      */
     public function startTrans()
     {
@@ -782,7 +783,7 @@ abstract class Connection
     /**
      * 是否断线
      * @access protected
-     * @param \PDOException  $e 异常对象
+     * @param \PDOException|\Exception  $e 异常对象
      * @return bool
      */
     protected function isBreak($e)

--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -2336,7 +2336,7 @@ class Query
             $modelName = $this->model;
             if (count($resultSet) > 0) {
                 foreach ($resultSet as $key => $result) {
-                    /** @var Model $result */
+                    /** @var Model $model */
                     $model = new $modelName($result);
                     $model->isUpdate(true);
 
@@ -2392,6 +2392,7 @@ class Query
      * @param mixed     $value   缓存数据
      * @param array     $options 缓存参数
      * @param array     $bind    绑定参数
+     * @return string
      */
     protected function getCacheKey($value, $options, $bind = [])
     {

--- a/library/think/db/builder/Sqlite.php
+++ b/library/think/db/builder/Sqlite.php
@@ -22,6 +22,7 @@ class Sqlite extends Builder
     /**
      * limit
      * @access public
+     * @param string $limit
      * @return string
      */
     public function parseLimit($limit)

--- a/library/think/model/relation/BelongsTo.php
+++ b/library/think/model/relation/BelongsTo.php
@@ -11,6 +11,7 @@
 
 namespace think\model\relation;
 
+use think\db\Query;
 use think\Loader;
 use think\Model;
 
@@ -68,7 +69,6 @@ class BelongsTo extends OneToOne
      * @param string  $operator 比较操作符
      * @param integer $count    个数
      * @param string  $id       关联表的统计字段
-     * @param string  $joinType JOIN类型
      * @return Query
      */
     public function has($operator = '>=', $count = 1, $id = '*')


### PR DESCRIPTION
代码中部分函数存在**文档注释与实际不相符**的情况，进而进行了相关修复以及调整
１、修复形参类型/返回值与文档注释丢失/不匹配的情况
２、修复部分错别字，例如$lmit($limit),$locl($lock)
３、部分函数直接调用可能会引起错误,且由于未申明而直接调用，会引起部分IDE会直接报出警告。所以在调用前新增了判断。