### PR TITLE
修Instance Trait实例化返回self更改为static

### DIFF
--- a/library/traits/think/Instance.php
+++ b/library/traits/think/Instance.php
@@ -24,7 +24,7 @@ trait Instance
     public static function instance($options = [])
     {
         if (is_null(self::$instance)) {
-            self::$instance = new self($options);
+            self::$instance = new static($options);
         }
         return self::$instance;
     }


### PR DESCRIPTION
```php
trait Instance
{
    protected static $instance = null;

    public static function instance($options = [])
    {
        if (is_null(self::$instance)) {
            self::$instance = new self($options);
        }
        return self::$instance;
    }
}


class father
{
    use Instance;
}

class son extends father
{
}


var_dump(son::instance()); // 目前返回结果为class father#1 (0){}
```
在father对象没被其他类继承的时候，`static`和`self`没有区别。
但是在**被其他类继承**时，个人认为返回son对象更符合预期。