### PR TITLE
优先使用Cookie中的语言设置

### DIFF
--- a/library/think/Lang.php
+++ b/library/think/Lang.php
@@ -160,6 +160,9 @@ class Lang
         if (isset($_GET[self::$langDetectVar])) {
             // url中设置了语言变量
             $langSet = strtolower($_GET[self::$langDetectVar]);
+        } elseif (isset($_COOKIE[self::$langCookieVar])) {
+            // Cookie中设置了语言变量
+            $langSet = strtolower($_COOKIE[self::$langCookieVar]);
         } elseif (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
             // 自动侦测浏览器语言
             preg_match('/^([a-z\d\-]+)/i', $_SERVER['HTTP_ACCEPT_LANGUAGE'], $matches);


### PR DESCRIPTION
多语言自动切换时，优先使用COOKIE中的语言设置，方便保持用户自己选择的语言。