### PR TITLE
修正域名路由bug

### DIFF
--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -251,7 +251,11 @@ class Route
         if (is_null($domain)) {
             $domain = $this->domain;
         }
-
+        if(isset($this->bind[$domain])){
+            return $this->bind[$domain];
+        }
+        $domain=explode(".",$domain,-2);
+        $domain=implode(".",$domain);
         return isset($this->bind[$domain]) ? $this->bind[$domain] : null;
     }
 


### PR DESCRIPTION
此bug重现
```
$app->route->domain('api.test','api');
```
此时域名绑定路由无效，但
```
$app->route->domain('api.test.xxx.com','api');
```
就有效。
同时，
```
$app->url->build('xxx/xxx');
```
也是会得到错误的结果。
此pr修复了以上问题。

另外，`tp`还是公司的形式在做开发吗？像我们这种第三方的，但想加入到tp开发中的话，可以考虑接纳加入tp团队吗。
