### PR TITLE
修复model两个bug

### DIFF
--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -838,6 +838,8 @@ abstract class Builder
             $value    = array_values($data);
             $values[] = 'SELECT ' . implode(',', $value);
         }
+        //上面使用的同名变量，这里先释放掉
+        unset($fields);
 
         foreach (array_keys(reset($dataSet)) as $field) {
             $fields[] = $this->parseKey($query, $field);

--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -143,7 +143,7 @@ class Query
     public function setConnection(Connection $connection)
     {
         $this->connection = $connection;
-
+        $this->prefix = $this->connection->getConfig('prefix');
         return $this;
     }
 
@@ -217,7 +217,7 @@ class Query
     public function connect($config = [], $name = false)
     {
         $this->connection = Connection::instance($config, $name);
-
+        $this->prefix = $this->connection->getConfig('prefix');
         return $this;
     }
 


### PR DESCRIPTION
## 修复模型自定义表前缀无效。
原因是构造函数里设置了默认的表前缀，而自定义model的connect时，不会重新设置自定义的表前缀，导致自定义表前缀无效。

修复insert生成的sql语句错误。
重用`$fields`只用没有清空原有数据，导致生成的sql语句异常。