### PR TITLE
修复 date 标签

### DIFF
--- a/library/think/Template.php
+++ b/library/think/Template.php
@@ -1059,7 +1059,8 @@ class Template
                     case 'raw':
                         continue;
                     case 'date':
-                        $name = 'date(' . $args[1] . ',strtotime(' . $name . ') ?: ' . $name . ')';
+                        $date = 'is_numeric(' . $name . ')?' . $name . ':(strtotime(' . $name . '))';
+                        $name = 'date(' . $args[1] . ',' . $date . ')';
                         break;
                     case 'first':
                         $name = 'current(' . $name . ')';


### PR DESCRIPTION
**`strtotime`不返回`false`并不代表工作正常**
```php
php -r "var_dump(strtotime(1255591112)?:'ok!');"
Command line code:1:
int(-27054471841)
```

这只是一个临时的修复方案