### PR TITLE
调整Config相关单元测试用例

### DIFF
--- a/tests/thinkphp/library/think/config/ConfigInitTrait.php
+++ b/tests/thinkphp/library/think/config/ConfigInitTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * 测试用例在使用Config时(如reset),可能会影响其他测试用例
+ * 此Trait在每次执行测试用例后会对Config进行还原
+ */
+namespace tests\thinkphp\library\think\config;
+
+use think\Config;
+
+trait ConfigInitTrait
+{
+    /**
+     * @var \Closure
+     */
+    protected static $internalConfigFoo;
+
+    /**
+     * @var \Closure
+     */
+    protected static $internalRangeFoo;
+
+    /**
+     * @var mixed
+     */
+    protected static $originConfig;
+
+    /**
+     * @var string
+     */
+    protected static $originRange;
+
+    public static function setUpBeforeClass()
+    {
+        self::$internalConfigFoo = \Closure::bind(function($value = null) {
+            return !is_null($value) ? Config::$config = $value : Config::$config;
+        }, null, Config::class);
+
+        self::$internalRangeFoo  = \Closure::bind(function($value = null) {
+            return !is_null($value) ? Config::$range = $value : Config::$range;
+        }, null, Config::class);
+
+        self::$originConfig = call_user_func(self::$internalConfigFoo);
+        self::$originRange  = call_user_func(self::$internalRangeFoo);
+    }
+
+    public function tearDown()
+    {
+        call_user_func(self::$internalConfigFoo, self::$originConfig);
+        call_user_func(self::$internalRangeFoo, self::$originRange);
+    }
+}

--- a/tests/thinkphp/library/think/config/ConfigInitTrait.php
+++ b/tests/thinkphp/library/think/config/ConfigInitTrait.php
@@ -34,11 +34,11 @@ trait ConfigInitTrait
     {
         self::$internalConfigFoo = \Closure::bind(function($value = null) {
             return !is_null($value) ? Config::$config = $value : Config::$config;
-        }, null, Config::class);
+        }, null, '\\Think\\Config');
 
         self::$internalRangeFoo  = \Closure::bind(function($value = null) {
             return !is_null($value) ? Config::$range = $value : Config::$range;
-        }, null, Config::class);
+        }, null, '\\Think\\Config');
 
         self::$originConfig = call_user_func(self::$internalConfigFoo);
         self::$originRange  = call_user_func(self::$internalRangeFoo);

--- a/tests/thinkphp/library/think/config/driver/iniTest.php
+++ b/tests/thinkphp/library/think/config/driver/iniTest.php
@@ -16,10 +16,13 @@
 
 namespace tests\thinkphp\library\think\config\driver;
 
+use tests\thinkphp\library\think\config\ConfigInitTrait;
 use think\config;
 
 class iniTest extends \PHPUnit_Framework_TestCase
 {
+    use ConfigInitTrait;
+
     public function testParse()
     {
         Config::parse('inistring=1', 'ini');

--- a/tests/thinkphp/library/think/config/driver/jsonTest.php
+++ b/tests/thinkphp/library/think/config/driver/jsonTest.php
@@ -16,10 +16,13 @@
 
 namespace tests\thinkphp\library\think\config\driver;
 
+use tests\thinkphp\library\think\config\ConfigInitTrait;
 use think\config;
 
 class jsonTest extends \PHPUnit_Framework_TestCase
 {
+    use ConfigInitTrait;
+
     public function testParse()
     {
         Config::parse('{"jsonstring":1}', 'json');

--- a/tests/thinkphp/library/think/config/driver/xmlTest.php
+++ b/tests/thinkphp/library/think/config/driver/xmlTest.php
@@ -16,10 +16,13 @@
 
 namespace tests\thinkphp\library\think\config\driver;
 
+use tests\thinkphp\library\think\config\ConfigInitTrait;
 use think\config;
 
 class xmlTest extends \PHPUnit_Framework_TestCase
 {
+    use ConfigInitTrait;
+
     public function testParse()
     {
         Config::parse('<?xml version="1.0"?><document><xmlstring>1</xmlstring></document>', 'xml');

--- a/tests/thinkphp/library/think/controllerTest.php
+++ b/tests/thinkphp/library/think/controllerTest.php
@@ -17,6 +17,7 @@
 namespace tests\thinkphp\library\think;
 
 use ReflectionClass;
+use think\Config;
 use think\Controller;
 use think\Request;
 use think\View;

--- a/tests/thinkphp/library/think/requestTest.php
+++ b/tests/thinkphp/library/think/requestTest.php
@@ -157,15 +157,31 @@ class requestTest extends \PHPUnit_Framework_TestCase
 
     public function testIsAjax()
     {
-        $request                          = Request::create('');
+        $request = Request::create('');
+
+        $this->assertFalse($request->isAjax());
+
         $_SERVER['HTTP_X_REQUESTED_WITH'] = 'xmlhttprequest';
+        $this->assertFalse($request->isAjax());
+        $this->assertFalse($request->isAjax(true));
+
+        $request->server(['HTTP_X_REQUESTED_WITH' => 'xmlhttprequest']);
         $this->assertTrue($request->isAjax());
     }
 
     public function testIsPjax()
     {
-        $request                = Request::create('');
+        $request = Request::create('');
+
+        $this->assertFalse($request->isPjax());
+
         $_SERVER['HTTP_X_PJAX'] = true;
+        $this->assertFalse($request->isPjax());
+        $this->assertFalse($request->isPjax(true));
+
+        $request->server(['HTTP_X_PJAX' => true]);
+        $this->assertTrue($request->isPjax());
+        $request->server(['HTTP_X_PJAX' => false]);
         $this->assertTrue($request->isPjax());
     }
 


### PR DESCRIPTION
目前部分测试用例在执行Config部分操作后会存在影响其他测试用例的情况。
譬如部分测试用例在执行中会调用Config::reset操作清空配置，最后会影响其他的测试用例。
例如在requestTest::isAjax中，会调用Config::get('var_ajax')，预期上理应返回convention中预设的值，然而Config在执行reset后清空了所有的值，导致后续的测试用例执行结果会与预期不符。