### PR TITLE
新增Jump测试用例

### DIFF
--- a/library/traits/controller/Jump.php
+++ b/library/traits/controller/Jump.php
@@ -36,8 +36,8 @@ trait Jump
      */
     protected function success($msg = '', $url = null, $data = '', $wait = 3, array $header = [])
     {
-        if (is_null($url) && isset($_SERVER["HTTP_REFERER"])) {
-            $url = $_SERVER["HTTP_REFERER"];
+        if (is_null($url) && !is_null(Request::instance()->server('HTTP_REFERER'))) {
+            $url = Request::instance()->server('HTTP_REFERER');
         } elseif ('' !== $url) {
             $url = (strpos($url, '://') || 0 === strpos($url, '/')) ? $url : Url::build($url);
         }
@@ -50,6 +50,7 @@ trait Jump
         ];
 
         $type = $this->getResponseType();
+
         if ('html' == strtolower($type)) {
             $result = ViewTemplate::instance(Config::get('template'), Config::get('view_replace_str'))
                 ->fetch(Config::get('dispatch_success_tmpl'), $result);
@@ -107,7 +108,7 @@ trait Jump
         $result = [
             'code' => $code,
             'msg'  => $msg,
-            'time' => $_SERVER['REQUEST_TIME'],
+            'time' => Request::instance()->server('REQUEST_TIME'),
             'data' => $data,
         ];
         $type     = $type ?: $this->getResponseType();

--- a/tests/thinkphp/library/think/urlTest.php
+++ b/tests/thinkphp/library/think/urlTest.php
@@ -16,12 +16,14 @@
 
 namespace tests\thinkphp\library\think;
 
+use tests\thinkphp\library\think\config\ConfigInitTrait;
 use think\Config;
 use think\Route;
 use think\Url;
 
 class urlTest extends \PHPUnit_Framework_TestCase
 {
+    use ConfigInitTrait;
 
     public function setUp()
     {
@@ -107,11 +109,11 @@ class urlTest extends \PHPUnit_Framework_TestCase
     {
         Config::set('url_domain_deploy', true);
         Route::domain('subdomain.thinkphp.cn', 'admin');
-        $this->assertEquals('http://subdomain.thinkphp.cn/blog/10.shtml', Url::build('/blog/10'));
+        $this->assertEquals('http://subdomain.thinkphp.cn/blog/10.html', Url::build('/blog/10'));
         Route::domain('subdomain.thinkphp.cn', [
             'hello/:name' => 'index/hello',
         ]);
-        $this->assertEquals('http://subdomain.thinkphp.cn/hello/thinkphp.shtml', Url::build('index/hello?name=thinkphp'));
+        $this->assertEquals('http://subdomain.thinkphp.cn/hello/thinkphp.html', Url::build('index/hello?name=thinkphp'));
     }
 
     public function testRoot()

--- a/tests/thinkphp/library/traits/controller/.gitignore
+++ b/tests/thinkphp/library/traits/controller/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/tests/thinkphp/library/traits/controller/jumpTest.php
+++ b/tests/thinkphp/library/traits/controller/jumpTest.php
@@ -1,0 +1,336 @@
+<?php
+namespace tests\thinkphp\library\traits\controller;
+
+use think\Config;
+use think\exception\HttpResponseException;
+use think\Request;
+use think\Response;
+use think\response\Redirect;
+use think\View;
+use traits\controller\Jump;
+
+class jumpTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var testClassWithJump
+     */
+    protected $testClass;
+
+    /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
+     * @var mixed
+     */
+    protected $originServerData;
+
+    public function setUp()
+    {
+        $this->testClass = new testClassWithJump();
+        $this->request   = Request::create('');
+
+        $this->originServerData = Request::instance()->server();
+    }
+
+    public function tearDown()
+    {
+        Request::instance()->server($this->originServerData);
+    }
+
+    /**
+     * @dataProvider provideTestSuccess
+     */
+    public function testSuccess($arguments, $expected, array $extra)
+    {
+        if (isset($extra['server'])) {
+            $this->request->server($extra['server']);
+        }
+
+        $mock = $this->getMockBuilder(get_class($this->testClass))->setMethods(['getResponseType'])->getMock();
+        $mock->expects($this->any())->method('getResponseType')->willReturn($extra['return']);
+
+        try {
+            call_user_func_array([$mock, 'success'], $arguments);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\\think\\exception\\HttpResponseException', $e);
+
+            /** @var Response $response */
+            $response = $e->getResponse();
+
+            $this->assertInstanceOf('\\Think\\Response', $response);
+            $this->assertEquals($expected['header'], $response->getHeader());
+            $this->assertEquals($expected['data'], $response->getData());
+        }
+    }
+
+    /**
+     * @dataProvider provideTestError
+     */
+    public function testError($arguments, $expected, array $extra)
+    {
+        if (isset($extra['server'])) {
+            $this->request->server($extra['server']);
+        }
+
+        $mock = $this->getMockBuilder(get_class($this->testClass))->setMethods(['getResponseType'])->getMock();
+        $mock->expects($this->any())->method('getResponseType')->willReturn($extra['return']);
+
+        try {
+            call_user_func_array([$mock, 'error'], $arguments);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\\think\\exception\\HttpResponseException', $e);
+
+            /** @var Response $response */
+            $response = $e->getResponse();
+
+            $this->assertInstanceOf('\\Think\\Response', $response);
+            $this->assertEquals($expected['header'], $response->getHeader());
+            $this->assertEquals($expected['data'], $response->getData());
+        }
+    }
+
+    /**
+     * @dataProvider provideTestResult
+     */
+    public function testResult($arguments, $expected, array $extra)
+    {
+        if (isset($extra['server'])) {
+            $this->request->server($extra['server']);
+        }
+
+        $mock = $this->getMockBuilder(get_class($this->testClass))->setMethods(['getResponseType'])->getMock();
+        $mock->expects($this->any())->method('getResponseType')->willReturn($extra['return']);
+
+        try {
+            call_user_func_array([$mock, 'result'], $arguments);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\\think\\exception\\HttpResponseException', $e);
+
+            /** @var Response $response */
+            $response = $e->getResponse();
+
+            $this->assertInstanceOf('\\Think\\Response', $response);
+            $this->assertEquals($expected['header'], $response->getHeader());
+            $this->assertEquals($expected['data'], $response->getData());
+        }
+    }
+
+    /**
+     * @dataProvider provideTestRedirect
+     */
+    public function testRedirect($arguments, $expected)
+    {
+        try {
+            call_user_func_array([$this->testClass, 'redirect'], $arguments);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\\think\\exception\\HttpResponseException', $e);
+
+            /** @var Redirect $response */
+            $response = $e->getResponse();
+            $this->assertInstanceOf('\\think\\response\\Redirect', $response);
+
+            $this->assertEquals($expected['url'], $response->getTargetUrl());
+            $this->assertEquals($expected['code'], $response->getCode());
+        }
+    }
+
+    public function testGetResponseType()
+    {
+        Request::instance()->server(['HTTP_X_REQUESTED_WITH' => null]);
+        $this->assertEquals('html', $this->testClass->getResponseType());
+
+        Request::instance()->server(['HTTP_X_REQUESTED_WITH' => true]);
+        $this->assertEquals('html', $this->testClass->getResponseType());
+
+        Request::instance()->server(['HTTP_X_REQUESTED_WITH' => 'xmlhttprequest']);
+        $this->assertEquals('json', $this->testClass->getResponseType());
+    }
+
+    public function provideTestSuccess()
+    {
+        $provideData = [];
+
+        $arguments = ['', null, '', 3, []];
+        $expected  = [
+            'header' => [
+                'Content-Type' => 'text/html; charset=utf-8'
+            ],
+            'data'   => View::instance(Config::get('template'), Config::get('view_replace_str'))
+                ->fetch(Config::get('dispatch_error_tmpl'), [
+                    'code' => 1,
+                    'msg'  => '',
+                    'data' => '',
+                    'url'  => '/index.php/',
+                    'wait' => 3,
+                ])
+        ];
+        $provideData[] = [$arguments, $expected, ['server' => ['HTTP_REFERER' => null], 'return' => 'html']];
+
+        $arguments = ['thinkphp', null, ['foo'], 4, ['Power-By' => 'thinkphp', 'Content-Type' => 'text/html; charset=gbk']];
+        $expected  = [
+            'header' => [
+                'Content-Type' => 'text/html; charset=gbk',
+                'Power-By' => 'thinkphp'
+            ],
+            'data'   => View::instance(Config::get('template'), Config::get('view_replace_str'))
+                ->fetch(Config::get('dispatch_error_tmpl'), [
+                    'code' => 1,
+                    'msg'  => 'thinkphp',
+                    'data' => ['foo'],
+                    'url'  => 'http://www.thinkphp.cn',
+                    'wait' => 4,
+                ])
+        ];
+        $provideData[] = [$arguments, $expected, ['server' => ['HTTP_REFERER' => 'http://www.thinkphp.cn'], 'return' => 'html']];
+
+        $arguments = ['thinkphp', 'index', ['foo'], 5, []];
+        $expected  = [
+            'header' => [
+                'Content-Type' => 'application/json; charset=utf-8'
+            ],
+            'data'   => [
+                'code' => 1,
+                'msg'  => 'thinkphp',
+                'data' => ['foo'],
+                'url'  => '/index.php/index.html',
+                'wait' => 5,
+                ]
+        ];
+        $provideData[] = [$arguments, $expected, ['server' => ['HTTP_REFERER' => null], 'return' => 'json']];
+
+        return $provideData;
+    }
+
+    public function provideTestError()
+    {
+        $provideData = [];
+
+        $arguments = ['', null, '', 3, []];
+        $expected  = [
+            'header' => [
+                'Content-Type' => 'text/html; charset=utf-8'
+            ],
+            'data'   => View::instance(Config::get('template'), Config::get('view_replace_str'))
+                ->fetch(Config::get('dispatch_error_tmpl'), [
+                    'code' => 0,
+                    'msg'  => '',
+                    'data' => '',
+                    'url'  => 'javascript:history.back(-1);',
+                    'wait' => 3,
+                ])
+        ];
+        $provideData[] = [$arguments, $expected, ['return' => 'html']];
+
+        $arguments = ['thinkphp', 'http://www.thinkphp.cn', ['foo'], 4, ['Power-By' => 'thinkphp', 'Content-Type' => 'text/html; charset=gbk']];
+        $expected  = [
+            'header' => [
+                'Content-Type' => 'text/html; charset=gbk',
+                'Power-By' => 'thinkphp'
+            ],
+            'data'   => View::instance(Config::get('template'), Config::get('view_replace_str'))
+                ->fetch(Config::get('dispatch_error_tmpl'), [
+                    'code' => 0,
+                    'msg'  => 'thinkphp',
+                    'data' => ['foo'],
+                    'url'  => 'http://www.thinkphp.cn',
+                    'wait' => 4,
+                ])
+        ];
+        $provideData[] = [$arguments, $expected, ['return' => 'html']];
+
+        $arguments = ['thinkphp', '', ['foo'], 5, []];
+        $expected  = [
+            'header' => [
+                'Content-Type' => 'application/json; charset=utf-8'
+            ],
+            'data'   => [
+                'code' => 0,
+                'msg'  => 'thinkphp',
+                'data' => ['foo'],
+                'url'  => '',
+                'wait' => 5,
+            ]
+        ];
+        $provideData[] = [$arguments, $expected, ['return' => 'json']];
+
+        return $provideData;
+    }
+
+    public function provideTestResult()
+    {
+        $provideData = [];
+
+        $arguments = [null, 0, '', '', []];
+        $expected  = [
+            'header' => [
+                'Content-Type' => 'text/html; charset=utf-8'
+            ],
+            'data' => [
+                    'code' => 0,
+                    'msg'  => '',
+                    'time' => Request::create('')->server('REQUEST_TIME'),
+                    'data' => null,
+                ]
+        ];
+        $provideData[] = [$arguments, $expected, ['return' => 'html']];
+
+        $arguments = [['foo'], 200, 'thinkphp', 'json', ['Power-By' => 'thinkphp']];
+        $expected  = [
+            'header' => [
+                'Power-By' => 'thinkphp',
+                'Content-Type' => 'application/json; charset=utf-8'
+            ],
+            'data'   => [
+                'code' => 200,
+                'msg'  => 'thinkphp',
+                'time' => 1000,
+                'data' => ['foo'],
+            ]
+        ];
+
+        $provideData[] = [$arguments, $expected, ['server' => ['REQUEST_TIME' => 1000], 'return' => 'json']];
+
+        return $provideData;
+    }
+
+    public function provideTestRedirect()
+    {
+        $provideData = [];
+
+        $arguments = ['', [], 302, []];
+        $expected  = [
+            'code'=> 302,
+            'url' => '/index.php/'
+        ];
+        $provideData[] = [$arguments, $expected, []];
+
+        $arguments = ['index', 302, null, []];
+        $expected  = [
+            'code'=> 302,
+            'url' => '/index.php/index.html'
+        ];
+        $provideData[] = [$arguments, $expected, []];
+
+        $arguments = ['http://www.thinkphp.cn', 301, 302, []];
+        $expected  = [
+            'code'=> 301,
+            'url' => 'http://www.thinkphp.cn'
+        ];
+        $provideData[] = [$arguments, $expected, []];
+
+        return $provideData;
+    }
+}
+
+class testClassWithJump
+{
+    use Jump {
+        success as public;
+        error as public;
+        result as public;
+        redirect as public;
+        getResponseType as public;
+    }
+}


### PR DESCRIPTION
1、在Jump.php中，使用Request::instance()->server代替$_SERVER
2、新增JumpTrait的测试用例