### PR TITLE
路由标识设置异常修复

### DIFF
--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -368,7 +368,8 @@ class Route
     {
         // 读取路由标识
         if (is_array($rule)) {
-            list($name, $rule) = $rule;
+            $name = $rule[0];
+            $rule = $rule[1];
         } elseif ($this->ruleName) {
             $name = $this->ruleName;
 


### PR DESCRIPTION
list($name, $rule) = $rule; 中$rule变量名相同 在php5.6下$name值异常