### PR TITLE
执行路由缓存命令前检测RUNTIME_PATH是否存在

### DIFF
--- a/library/think/console/command/optimize/Route.php
+++ b/library/think/console/command/optimize/Route.php
@@ -27,6 +27,11 @@ class Route extends Command
 
     protected function execute(Input $input, Output $output)
     {
+
+        if (!is_dir(RUNTIME_PATH)) {
+            @mkdir(RUNTIME_PATH, 0755, true);
+        }
+
         file_put_contents(RUNTIME_PATH . 'route.php', $this->buildRouteCache());
         $output->writeln('<info>Succeed!</info>');
     }


### PR DESCRIPTION
如果RUNTIME_PATH目录不存在，单独执行这个命令会报错的