### PR TITLE
修复Rest资源类型正则匹配错误

### DIFF
--- a/library/think/controller/Rest.php
+++ b/library/think/controller/Rest.php
@@ -43,7 +43,7 @@ abstract class Rest
         if ('' == $ext) {
             // 自动检测资源类型
             $this->type = $request->type();
-        } elseif (!preg_match('/\(' . $this->restTypeList . '\)$/i', $ext)) {
+        } elseif (!preg_match('/(' . $this->restTypeList . ')$/i', $ext)) {
             // 资源类型非法 则用默认资源类型访问
             $this->type = $this->restDefaultType;
         } else {
@@ -51,7 +51,7 @@ abstract class Rest
         }
         // 请求方式检测
         $method = strtolower($request->method());
-        if (false === stripos($this->restMethodList, $method)) {
+        if (!preg_match('/(' . $this->restMethodList . ')$/i', $method)) {
             // 请求方式非法 则用默认请求方法
             $method = $this->restDefaultMethod;
         }


### PR DESCRIPTION
匹配资源类型目前的正则表达式为
```php
/\(html|xml|json|rss\)$/i
```
而实际期望应为
```php
/(html|xml|json|rss)$/i
```