### PR TITLE
修正console.php路径判断

### DIFF
--- a/console.php
+++ b/console.php
@@ -16,5 +16,5 @@ namespace think;
 require __DIR__ . '/base.php';
 
 // 执行应用
-Container::get('app', [__DIR__ . '/../application/'])->initialize();
+Container::get('app', [__DIR__ . (strpos(__DIR__, 'vendor/topthink/framework') === false ? '/../' : '/../../../') . 'application/'])->initialize();
 Console::init();


### PR DESCRIPTION
https://github.com/top-think/framework/commit/5438560ec94288bff77b71a8103962b8815e9c89
由此commit引起的问题
如果框架安装在Composer的vendor目录下（而不是默认的根目录下），console.php中获取到的路径是不正确的。

可能有更好的判断方法，希望修正。