### PR TITLE
Redis Session驱动和Jump跳转html渲染的修改

### DIFF
--- a/library/think/response/Jump.php
+++ b/library/think/response/Jump.php
@@ -1,0 +1,36 @@
+<?php
+// +----------------------------------------------------------------------
+// | ThinkPHP [ WE CAN DO IT JUST THINK ]
+// +----------------------------------------------------------------------
+// | Copyright (c) 2006~2017 http://thinkphp.cn All rights reserved.
+// +----------------------------------------------------------------------
+// | Licensed ( http://www.apache.org/licenses/LICENSE-2.0 )
+// +----------------------------------------------------------------------
+// | Author: liu21st <liu21st@gmail.com>
+// +----------------------------------------------------------------------
+
+namespace think\response;
+
+use think\Container;
+use think\Response;
+
+class Jump extends Response
+{
+    protected $contentType = 'text/html';
+
+    /**
+     * 处理数据
+     * @access protected
+     * @param mixed $data 要处理的数据
+     * @return mixed
+     * @throws \Exception
+     */
+    protected function output($data)
+    {
+        $config = Container::get('config');
+        $data   = Container::get('view')
+            ->init($config->pull('template'), $config->get('view_replace_str'))
+            ->fetch($config->get('dispatch_error_tmpl'), $data);
+        return $data;
+    }
+}

--- a/library/think/session/driver/Redis.php
+++ b/library/think/session/driver/Redis.php
@@ -127,4 +127,43 @@ class Redis extends SessionHandler
     {
         return true;
     }
+
+    /**
+     * Redis Session 驱动的加锁机制
+     * @access public
+     * @param  string  $sessID   用于加锁的sessID
+     * @param  integer $timeout 默认过期时间
+     * @return bool
+     */
+    public function lock($sessID, $timeout = 10)
+    {
+        if ($this->handler == null) {
+            $this->open('', '');
+        }
+
+        $lockKey = 'LOCK_PREFIX_' . $sessID;
+        // 使用setnx操作加锁
+        $isLock = $this->handler->setnx($lockKey, 1);
+        if ($isLock) {
+            // 设置过期时间，防止死任务的出现
+            $this->handler->expire($lockKey, $timeout);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Redis Session 驱动的解锁机制
+     * @access public
+     * @param  string  $sessID   用于解锁的sessID
+     */
+    public function unlock($sessID)
+    {
+        if ($this->handler == null) {
+            $this->open('', '');
+        }
+
+        $this->handler->del('LOCK_PREFIX_' . $sessID);
+    }
 }

--- a/library/traits/controller/Jump.php
+++ b/library/traits/controller/Jump.php
@@ -48,12 +48,16 @@ trait Jump
 
         $type = $this->getResponseType();
 
-        if ('html' == strtolower($type)) {
-            $config = Container::get('config');
-            $result = Container::get('view')
-                ->init($config->pull('template'), $config->get('view_replace_str'))
-                ->fetch($config->get('dispatch_success_tmpl'), $result);
-        }
+        // 把跳转模板的渲染下沉，这样在 response_send 行为里通过getData()获得的数据是一致性的格式
+        // 这个修改不会对原框架产生任何影响，希望合并
+        $type = 'html' == strtolower($type) ? 'jump' : $type;
+
+        // if ('html' == strtolower($type)) {
+        //     $config = Container::get('config');
+        //     $result = Container::get('view')
+        //         ->init($config->pull('template'), $config->get('view_replace_str'))
+        //         ->fetch($config->get('dispatch_success_tmpl'), $result);
+        // }
 
         $response = Response::create($result, $type)->header($header);
 
@@ -88,12 +92,16 @@ trait Jump
 
         $type = $this->getResponseType();
 
-        if ('html' == strtolower($type)) {
-            $config = Container::get('config');
-            $result = Container::get('view')
-                ->init($config->pull('template'), $config->get('view_replace_str'))
-                ->fetch($config->get('dispatch_error_tmpl'), $result);
-        }
+        // 把跳转模板的渲染下沉，这样在 response_send 行为里通过getData()获得的数据是一致性的格式
+        // 这个修改不会对原框架产生任何影响，希望合并
+        $type = 'html' == strtolower($type) ? 'jump' : $type;
+
+        // if ('html' == strtolower($type)) {
+        //     $config = Container::get('config');
+        //     $result = Container::get('view')
+        //         ->init($config->pull('template'), $config->get('view_replace_str'))
+        //         ->fetch($config->get('dispatch_error_tmpl'), $result);
+        // }
 
         $response = Response::create($result, $type)->header($header);
 


### PR DESCRIPTION
后台使用Redis Session。在登录业务中，用ajax方式同时刷新了验证码和token后，登录时出现token令牌不存在的问题。
故丢Redis驱动和Session类进行了加锁处理，可通过配置文件开启加锁功能。

对Redis Session的具体测试，可参考：https://www.zybuluo.com/conna45/note/914918

代码调整:
think\session\driver\Redis类新增了两个方法，分别是lock()和unlock()
think\Session类新增三个属性$lockDriver、$sessKey、$lockTimeout和三个方法initDriver()、lock()、unlock()

启用lock：在配置文件里，设置'use_lock'       => true,  如果Session驱动没有实现lock和unlock函数，则不会加锁