### PR TITLE
读取缓存模板匹配第一行的matches结果有时候字符串长度会有误差，需要重新计算一下。

### DIFF
--- a/library/think/Template.php
+++ b/library/think/Template.php
@@ -283,7 +283,10 @@ class Template
         if (!isset($matches[1])) {
             return false;
         }
-        $out = preg_replace_callback('#s:(\d+):"(.*?)";#s',function($match){return 's:'.strlen($match[2]).':"'.$match[2].'";';},$matches[1]);
+        $out = preg_replace_callback(
+            '#s:(\d+):"(.*?)";#s',function($match){
+                return 's:'.strlen($match[2]).':"'.$match[2].'";';
+            },$matches[1]);
         $includeFile = unserialize($out);
         if (!is_array($includeFile)) {
             return false;

--- a/library/think/Template.php
+++ b/library/think/Template.php
@@ -283,7 +283,8 @@ class Template
         if (!isset($matches[1])) {
             return false;
         }
-        $includeFile = unserialize($matches[1]);
+        $out = preg_replace_callback('#s:(\d+):"(.*?)";#s',function($match){return 's:'.strlen($match[2]).':"'.$match[2].'";';},$matches[1]);
+        $includeFile = unserialize($out);
         if (!is_array($includeFile)) {
             return false;
         }


### PR DESCRIPTION
更改代码格式重新提交。