### PR TITLE
 修复常驻进程下缓存不过期

### DIFF
--- a/library/think/cache/driver/File.php
+++ b/library/think/cache/driver/File.php
@@ -109,7 +109,7 @@ class File extends Driver
         $content = file_get_contents($filename);
         if (false !== $content) {
             $expire = (int) substr($content, 8, 12);
-            if (0 != $expire && $_SERVER['REQUEST_TIME'] > filemtime($filename) + $expire) {
+            if (0 != $expire && time() > filemtime($filename) + $expire) {
                 return $default;
             }
             $content = substr($content, 32);

--- a/library/think/cache/driver/Memcached.php
+++ b/library/think/cache/driver/Memcached.php
@@ -110,7 +110,7 @@ class Memcached extends Driver
             $first = true;
         }
         $key    = $this->getCacheKey($name);
-        $expire = 0 == $expire ? 0 : $_SERVER['REQUEST_TIME'] + $expire;
+        $expire = 0 == $expire ? 0 : time() + $expire;
         if ($this->handler->set($key, $value, $expire)) {
             isset($first) && $this->setTagItem($key);
             return true;


### PR DESCRIPTION
对于常驻内存应用 $_SERVER['REQUEST_TIME'] 时间为应用启动时间不会变，导致缓存不过期，改为time()。