### PR TITLE
PHP5.x不兼容throwable

### DIFF
--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -386,11 +386,6 @@ abstract class Connection
                 return $this->close()->query($sql, $bind, $master, $pdo);
             }
             throw new PDOException($e, $this->config, $this->getLastsql());
-        } catch (\Throwable $e) {
-            if ($this->isBreak($e)) {
-                return $this->close()->query($sql, $bind, $master, $pdo);
-            }
-            throw $e;
         } catch (\Exception $e) {
             if ($this->isBreak($e)) {
                 return $this->close()->query($sql, $bind, $master, $pdo);
@@ -454,11 +449,6 @@ abstract class Connection
                 return $this->close()->execute($sql, $bind);
             }
             throw new PDOException($e, $this->config, $this->getLastsql());
-        } catch (\Throwable $e) {
-            if ($this->isBreak($e)) {
-                return $this->close()->execute($sql, $bind);
-            }
-            throw $e;
         } catch (\Exception $e) {
             if ($this->isBreak($e)) {
                 return $this->close()->execute($sql, $bind);


### PR DESCRIPTION
目前TP最低向下兼容到PHP版本5.4
[http://php.net/manual/en/class.throwable.php](http://php.net/manual/en/class.throwable.php)
而Throwable是7.x才开始支持的
如果内部抛出不是`PDOException`，而是其他类型的exception，譬如`BindParamException`就会报错