### PR TITLE
非hhvm环境不设置session.auto_start

### DIFF
--- a/library/think/Session.php
+++ b/library/think/Session.php
@@ -53,7 +53,9 @@ class Session
 
         // 启动session
         if (!empty($config['auto_start']) && PHP_SESSION_ACTIVE != session_status()) {
-            ini_set('session.auto_start', 0);
+            if (strstr(PHP_VERSION, 'hhvm')) {
+                ini_set('session.auto_start', 0);
+            }
             $isDoStart = true;
         }
 

--- a/tests/thinkphp/library/think/sessionTest.php
+++ b/tests/thinkphp/library/think/sessionTest.php
@@ -124,8 +124,6 @@ class sessionTest extends \PHPUnit_Framework_TestCase
         // session_status()
         if (strstr(PHP_VERSION, 'hhvm')) {
             $this->assertEquals('', ini_get('session.auto_start'));
-        } else {
-            $this->assertEquals(0, ini_get('session.auto_start'));
         }
 
         $this->assertEquals($config['use_trans_sid'], ini_get('session.use_trans_sid'));


### PR DESCRIPTION
根据php文档，session.auto_start是在运行时更改是无效的，参考[这里 ](https://secure.php.net/manual/en/session.configuration.php)

所以，如果一开始就在配置中设置了`session.auto_start = 1`，那么 `ini_get('session.auto_start')` 将始终返回1.

