### PR TITLE
修复数字键名丢失问题

### DIFF
--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -187,7 +187,7 @@ class Validate
      */
     public function __construct(array $rules = [], array $message = [], array $field = [])
     {
-        $this->rule    = array_merge($this->rule, $rules);
+        $this->rule    = $rules + $this->rule;
         $this->message = array_merge($this->message, $message);
         $this->field   = array_merge($this->field, $field);
     }
@@ -214,7 +214,7 @@ class Validate
     public function rule($name, $rule = '')
     {
         if (is_array($name)) {
-            $this->rule = array_merge($this->rule, $name);
+            $this->rule = $name + $this->rule;
             if (is_array($rule)) {
                 $this->field = array_merge($this->field, $rule);
             }


### PR DESCRIPTION
修复数组包含数字键名，后面的值将不会覆盖原来的值，而是附加到后面，且键名会以连续方式重新索引，导致规则中键名丢失的情况。
Fixed a problem that the arrays contain numeric keys, the later value will not overwrite the original value, but will be appended, and values in the input array with numeric keys will be renumbered with incrementing keys starting from zero in the result array, caused the keys to be lost in the rules.