### PR TITLE
[5.0] 修复可能出现的重复require

### DIFF
--- a/library/think/Loader.php
+++ b/library/think/Loader.php
@@ -288,6 +288,10 @@ class Loader
         if (is_file(VENDOR_PATH . 'composer/autoload_files.php')) {
             $includeFiles = require VENDOR_PATH . 'composer/autoload_files.php';
             foreach ($includeFiles as $fileIdentifier => $file) {
+                if (isset($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
+                    continue;
+                }
+
                 if (empty(self::$autoloadFiles[$fileIdentifier])) {
                     __require_file($file);
                     self::$autoloadFiles[$fileIdentifier] = true;


### PR DESCRIPTION
一些提供可执行文件的composer依赖，譬如phpunit，这些在运行时会先载入composer的autoload文件，这时，如果我在phpunit的bootstrap文件里面初始化了TP，那么TP内部的Loader依然会require一遍composer下的`files`，有可能导致函数的重复定义。