### PR TITLE
对读取值为NULL的时间类型不作转换

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -440,6 +440,10 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
             // 类型转换
             $value = $this->readTransform($value, $this->type[$name]);
         } elseif (in_array($name, [$this->createTime, $this->updateTime])) {
+            if ($value === null) {
+                return null;
+            }
+            
             if (is_string($this->autoWriteTimestamp) && in_array(strtolower($this->autoWriteTimestamp), [
                 'datetime',
                 'date',


### PR DESCRIPTION
当数据库中字段的值为NULL时，读取到模型里就变成了`1970-01-01 08:00:00`（在设置了datetime_format为`Y-m-d H:i:s`的情况下），这导致了用户没办法通过模型判断该字段是否有值。