### PR TITLE
修正$r为null时导致的报错

### DIFF
--- a/library/think/process/pipes/Windows.php
+++ b/library/think/process/pipes/Windows.php
@@ -196,7 +196,7 @@ class Windows extends Pipes
             return;
         }
 
-        if (null !== $w && 0 < count($r)) {
+        if (null !== $r && 0 < count($r)) {
             $data = '';
             while ($dataread = fread($r['input'], self::CHUNK_SIZE)) {
                 $data .= $dataread;


### PR DESCRIPTION
修正$r为null时导致的报错。count的参数不能为null。