### PR TITLE
修正变量判断错误

### DIFF
--- a/library/think/process/pipes/Windows.php
+++ b/library/think/process/pipes/Windows.php
@@ -196,7 +196,7 @@ class Windows extends Pipes
             return;
         }
 
-        if (null !== $w && 0 < count($r)) {
+        if (null !== $r && 0 < count($r)) {
             $data = '';
             while ($dataread = fread($r['input'], self::CHUNK_SIZE)) {
                 $data .= $dataread;


### PR DESCRIPTION
修正变量判断错误，该错误会导致count函数的参数为null，然后报错