### PR TITLE
修复使用belongsToManyQuery时出现的Column not found错误

### DIFF
--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -782,7 +782,11 @@ class Query
             $prefix = $prefix ?: $tableName;
             foreach ($field as $key => $val) {
                 if (is_numeric($key)) {
-                    $val = $prefix . '.' . $val . ($alias ? ' AS ' . $alias . $val : '');
+                    if (empty($alias)) {
+                        $val = $prefix . '.' . $val;
+                    }else {
+                        $val = $this->raw('`' . $prefix . '`.`' . $val . '` AS `' . $alias . $val . '`');
+                    }
                 }
                 $field[$key] = $val;
             }


### PR DESCRIPTION
修复使用`belongsToManyQuery`时出现的**Column not found**错误