### PR TITLE
改进requireCallback:callable时方法只能放到公共文件中

### DIFF
--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -1078,7 +1078,7 @@ class Validate
      */
     public function requireCallback($value, $rule, $data)
     {
-        $result = call_user_func_array($rule, [$value, $data]);
+        $result = call_user_func_array([$this, $rule], [$value, $data]);
 
         if ($result) {
             return !empty($value) || '0' == $value;


### PR DESCRIPTION
改进requireCallback:callable时  callable 方法只能放到公共文件中 给验证带来极大的不方便