### PR TITLE
 类命名空间首字母转换成小写

### DIFF
--- a/library/think/Loader.php
+++ b/library/think/Loader.php
@@ -150,11 +150,11 @@ class Loader
         // 查找 PSR-4
         $logicalPathPsr4 = strtr($class, '\\', DIRECTORY_SEPARATOR) . '.php';
  
-        //首字母转换为小写
+        //类命名空间首字母转换为小写
         $first = strtolower($class[0]); 
 
-        //首字母转换为小写  转换后use Think\Controller 可用
-        $class =   lcfirst($class);
+        //类命名空间首字母转换为小写,转换后Think命名空间下的类可用,控制器中use Think\Controller也可使用
+        $class = lcfirst($class);
         
         if (isset(self::$prefixLengthsPsr4[$first])) {
             foreach (self::$prefixLengthsPsr4[$first] as $prefix => $length) {

--- a/library/think/Loader.php
+++ b/library/think/Loader.php
@@ -149,8 +149,13 @@ class Loader
 
         // 查找 PSR-4
         $logicalPathPsr4 = strtr($class, '\\', DIRECTORY_SEPARATOR) . '.php';
+ 
+        //首字母转换为小写
+        $first = strtolower($class[0]); 
 
-        $first = $class[0];
+        //首字母转换为小写  转换后use Think\Controller 可用
+        $class =   lcfirst($class);
+        
         if (isset(self::$prefixLengthsPsr4[$first])) {
             foreach (self::$prefixLengthsPsr4[$first] as $prefix => $length) {
                 if (0 === strpos($class, $prefix)) {


### PR DESCRIPTION
tp5命名空间为小写的think,那大写Think就没法用了,转换后use Think\Controller 可用。$first = strtolower($class[0]); 获取类命名空间的首字母,而在\vendor\composer\autoload_static.php中,$prefixLengthsPsr4属性中的键值是'a','t'小写,$first='T',这样Think命名空间下的类无法使用