### PR TITLE
将$config属性前的private修改为public

### DIFF
--- a/library/think/Config.php
+++ b/library/think/Config.php
@@ -17,7 +17,7 @@ class Config implements \ArrayAccess
      * 配置参数
      * @var array
      */
-    private $config = [];
+    public $config = [];
 
     /**
      * 配置前缀


### PR DESCRIPTION
$config 里面存放的是配置文件的信息，如果设置成private,外部类就算实例化本类也将无法获取到配置，改成public，允许外部类获取属性的值