### PR TITLE
修改db()函数参数$force默认为false

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -280,7 +280,7 @@ if (!function_exists('db')) {
      * @param bool          $force 是否强制重新连接
      * @return \think\db\Query
      */
-    function db($name = '', $config = [], $force = true)
+    function db($name = '', $config = [], $force = false)
     {
         return Db::connect($config, $force)->name($name);
     }


### PR DESCRIPTION
在`db()`函数默认重连数据库的情况下，使用事务可能出错。例子如下，

```
Db::startTrans();

Member::where(['id' => 1])->update(['balance' => 1000]);

db('address')->where(['id' => 1])->update(['collected' => 1]);

Member::where(['id' => 2])->update(['balance' => 2000]);

Db::commit();
```
由于第三行`db()`函数默认重新连接，第一行打开事务的连接实际上已经丢失，导致`Db::commit()`并没有生效。

```
// library/think/db/Connection.php:1702
    public function commit()
    {
        $this->initConnect(true);
        // 调用db()后$this->transTimes为0
        if (1 == $this->transTimes) {
            $this->linkID->commit();
        }

        --$this->transTimes;
    }
```

`$force`参数默认为`true`可以解读为：`db()`函数的使用者应该有数据库重新连接的预期。

然而我并没有这样的预期，不知道各位大神有没有？