### PR TITLE
base方法不存在

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -287,11 +287,6 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
             $this->withNoTrashed($query);
         }
 
-        // 全局作用域
-        if ($useBaseQuery && method_exists($this, 'base')) {
-            call_user_func_array([$this, 'base'], [ & $query]);
-        }
-
         // 返回当前模型的数据库查询对象
         return $query;
     }


### PR DESCRIPTION
base方法根本不存在,手册也没提有何用处。只有在模型中继承model类,并且创建public function base(){} 才会起作用,  call_user_func_array([$this, 'base'], [ & $query]); 把 \think\db\query 回调给base方法，不知何用处，建议删除