### PR TITLE
使 saveAll 批量添加带主键的数据时支持 replace()连贯操作

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -765,7 +765,7 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 if ($this->exists || (!empty($auto) && isset($data[$pk]))) {
                     $result[$key] = self::update($data, [], $this->field);
                 } else {
-                    $result[$key] = self::create($data, $this->field);
+                    $result[$key] = self::create($data, $this->field, $this->replace);
                 }
             }
 


### PR DESCRIPTION
使 saveAll 批量添加带主键的数据时支持 replace()连贯操作，例如：model('goods')->replace()->saveAll($result, false);