### PR TITLE
use_trans_sid失效

### DIFF
--- a/library/think/Session.php
+++ b/library/think/Session.php
@@ -126,7 +126,7 @@ class Session
 
         $isDoStart = false;
         if (isset($config['use_trans_sid'])) {
-            ini_set('session.use_trans_sid', $config['use_trans_sid'] ? 1 : 0);
+            ini_set('session.use_trans_sid', $config['use_trans_sid'] ? 1 && ini_set('session.use_only_cookies', 0) : 0);
         }
 
         // 启动session


### PR DESCRIPTION
session.use_only_cookies 是否使用cookie来保存session值,=1时,use_trans_sid失效