### PR TITLE
修正长整型字段在SQL日志中为科学计数法的问题

### DIFF
--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -1461,7 +1461,7 @@ abstract class Connection
             if (PDO::PARAM_STR == $type) {
                 $value = '\'' . addslashes($value) . '\'';
             } elseif (PDO::PARAM_INT == $type) {
-                $value = (float) $value;
+                $value = (int) $value;
             }
 
             // 判断占位符


### PR DESCRIPTION
解决长整型字段，如bigint(20)，查询时正常，但在SQL日志中被转为科学计数法的问题。
例：
[ 2018-07-19T18:20:00+08:00 ] 127.0.0.1 POST /park/test/sql?id=201805111642570130
[ sql ] [ SQL ] SELECT * FROM `order` WHERE  `order_id` = 2.0180511164257E+17 LIMIT 1 [ RunTime:0.017345s ]