### PR TITLE
更新PHP最低版本依赖和相关文档

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ GitHub 提供了 Issue 功能，该功能可以用于：
 或自行安装
 
 - Apache / Nginx
-- PHP 5.4 ~ 5.6
+- PHP 5.4 ~ 7.0
 - MySQL / MariaDB
 
 *Windows 用户推荐添加 PHP bin 目录到 PATH，方便使用 composer*

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ composer update topthink/framework
 
 ## 参与开发
 
-请参阅 [ThinkPHP5 核心框架包](https://github.com/top-think/framework)。
+请参阅 [ThinkPHP5 核心框架包 - 如何贡献我的源代码](https://github.com/top-think/framework/blob/5.1/CONTRIBUTING.md)。
 
 ## 版权信息
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ThinkPHP 5.1 —— 12载初心，你值得信赖的PHP框架
 [![Build Status](https://travis-ci.org/top-think/framework.svg?branch=master)](https://travis-ci.org/top-think/framework)
 [![Total Downloads](https://poser.pugx.org/topthink/framework/downloads)](https://packagist.org/packages/topthink/framework)
 [![Latest Stable Version](https://poser.pugx.org/topthink/framework/v/stable)](https://packagist.org/packages/topthink/framework)
-[![PHP Version](https://img.shields.io/badge/php-%3E%3D5.6-8892BF.svg)](http://www.php.net/)
+[![PHP Version](https://img.shields.io/badge/php-%3E%3D7.0-8892BF.svg)](http://www.php.net/)
 [![License](https://poser.pugx.org/topthink/framework/license)](https://packagist.org/packages/topthink/framework)
 
 ThinkPHP5.1对底层架构做了进一步的改进，减少依赖，其主要特性包括：
@@ -35,6 +35,8 @@ ThinkPHP5.1对底层架构做了进一步的改进，减少依赖，其主要特
  + 模型自动验证
 
 > ThinkPHP5.1的运行环境要求PHP5.6+。
+
+> ThinkPHP5.1.22以上版本的运行环境要求PHP7.0+。
 
 ## 安装
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.0.0",
         "topthink/think-installer": "2.*"
     },
     "require-dev": {


### PR DESCRIPTION
- 更新项目 `Composer` 对 `PHP` 最低版本依赖为 7.0.0
由于 v5.1.22 引入了对 [Yaconf] 的支持，`Yaconf`的最低 `PHP` 版本依赖为 7.0.0，故更新 `Composer` 对 `PHP` 的版本依赖，并同步更新文档说明。
- 补充完善参与开发贡献代码的 README 链接。

[Yaconf]:https://github.com/laruence/yaconf