### PR TITLE
修复软删除结果总是返回True的问题

### DIFF
--- a/library/think/model/concern/SoftDelete.php
+++ b/library/think/model/concern/SoftDelete.php
@@ -127,7 +127,7 @@ trait SoftDelete
 
         $this->exists(false);
 
-        return true;
+        return $result;
     }
 
     /**


### PR DESCRIPTION
既然delete()方法中有接收到删除操作的执行结果,为什么不直接返回这个结果,而是始终返回True呢?弱弱的问一句框架底层如何保证一定会删除成功?