### PR TITLE
前置控制器操作忽略大小写

### DIFF
--- a/library/think/Controller.php
+++ b/library/think/Controller.php
@@ -99,23 +99,25 @@ class Controller
     /**
      * 前置操作
      * @access protected
-     * @param  string $method  前置操作方法名
+     * @param  string $method  前置操作方法名(忽略大小写)
      * @param  array  $options 调用参数 ['only'=>[...]] 或者['except'=>[...]]
      */
     protected function beforeAction($method, $options = [])
     {
         if (isset($options['only'])) {
-            if (is_string($options['only'])) {
-                $options['only'] = explode(',', $options['only']);
+            if (is_array($options['only'])) {
+                $options['only'] = implode(',', $options['only']);
             }
-            if (!in_array($this->request->action(), $options['only'])) {
+            $options['only'] = explode(',', strtolower($options['only']));
+            if (!in_array(strtolower($this->request->action()), $options['only'])) {
                 return;
             }
         } elseif (isset($options['except'])) {
-            if (is_string($options['except'])) {
-                $options['except'] = explode(',', $options['except']);
+            if (is_array($options['except'])) {
+                $options['except'] = implode(',', $options['except']);
             }
-            if (in_array($this->request->action(), $options['except'])) {
+            $options['except'] = explode(',', strtolower($options['except']));
+            if (in_array(strtolower($this->request->action()), $options['except'])) {
                 return;
             }
         }


### PR DESCRIPTION
由于当前方法名的获取收受到大小写的影响，因此在定义前置操作时，容易产生大小写不对应而无法正确调用前置操作的现象：例如：
- $this->request->action() 返回 getdetail 
- $beforeActionList 中定义getDetail 
这样就产生明明定义了前置操作，但是却没有执行的情况，所以需要进行名称大小写处理

提交中使用了`implode->strtolower->explode` 的处理方式

另外：前置操作可以对控制器的方法进行权限控制，如果要废弃，希望能提供一种更改的权限控制方式