### PR TITLE
改进Socketlog扩展

### DIFF
--- a/library/think/log/driver/Socket.php
+++ b/library/think/log/driver/Socket.php
@@ -30,6 +30,8 @@ class Socket
         'force_client_ids'    => [],
         // 限制允许读取日志的client_id
         'allow_client_ids'    => [],
+        //输出到浏览器默认展开的日志级别
+        'expand_level'        => ['debug'],
     ];
 
     protected $css = [
@@ -95,7 +97,7 @@ class Socket
 
         foreach ($log as $type => $val) {
             $trace[] = [
-                'type' => 'groupCollapsed',
+                'type' => in_array($type, $this->config['expand_level']) ? 'group' : 'groupCollapsed',
                 'msg'  => '[ ' . $type . ' ]',
                 'css'  => isset($this->css[$type]) ? $this->css[$type] : '',
             ];


### PR DESCRIPTION
#### 支持自定义`默认展开日志类别`
- 默认`debug`级别信息在浏览器 console 输出时自动展开
- 通过配置`expand_level `选项自定义默认展开类别。方便调试。