### PR TITLE
路由里调用model或者validate助手函数

### DIFF
--- a/library/think/App.php
+++ b/library/think/App.php
@@ -675,7 +675,7 @@ class App extends Container
         }
 
         list($module, $class) = $this->parseModuleAndClass($name, $layer, $appendSuffix);
-        if(!$module) { 
+        if(!$module) {
             $class = str_replace('\\' . $layer . '\\', '\\' . $common.'\\'.$layer . '\\', $class);
         }
         if (class_exists($class)) {


### PR DESCRIPTION
route.php里调用 model,validate helper 的时候,module为空的处理!2018.09.16
