### PR TITLE
解决直接使用new xxModel()或静态调用时使用alias方法不生效的问题

### DIFF
--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -1672,6 +1672,9 @@ class Query
                 }
             } else {
                 $table = $this->getTable();
+                if (false !== strpos($table, '__')) {
+                    $table = $this->parseSqlTable($table);
+                }
             }
 
             $this->options['alias'][$table] = $alias;


### PR DESCRIPTION
在工作中多次想用
`XXModel::alias('a')->join('yy b','a.yid = b.id')`
但发现alias并没有生效，
这个问题应该存在很长时间了，使用起来很不方便，希望刘大大看看是否可以合并这段代码以解决。