### PR TITLE
多个文件上传报错，及多对多中间表依赖注入时，报"Cannot instantiate abstract class think\Model"

### DIFF
--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -1168,27 +1168,26 @@ class Request
      */
     public function file($name = '')
     {
-        if (empty($this->file)) {
-            $this->file = isset($_FILES) ? $_FILES : [];
+        if (strpos($name, '.')) {
+            list($name, $sub) = explode('.', $name);
         }
 
-        $files = $this->file;
-        if (!empty($files)) {
-            if (strpos($name, '.')) {
-                list($name, $sub) = explode('.', $name);
-            }
+        if (empty($this->file)) {
+            $files = isset($_FILES) ? $_FILES : [];
 
             // 处理上传文件
-            $array = $this->dealUploadFile($files, $name);
+            $this->file = $this->dealUploadFile($files, $name);
+        }
 
-            if ('' === $name) {
-                // 获取全部文件
-                return $array;
-            } elseif (isset($sub) && isset($array[$name][$sub])) {
-                return $array[$name][$sub];
-            } elseif (isset($array[$name])) {
-                return $array[$name];
-            }
+        $array = $this->file;
+
+        if ('' === $name) {
+            // 获取全部文件
+            return $array;
+        } elseif (isset($sub) && isset($array[$name][$sub])) {
+            return $array[$name][$sub];
+        } elseif (isset($array[$name])) {
+            return $array[$name];
         }
 
         return;

--- a/library/think/model/Pivot.php
+++ b/library/think/model/Pivot.php
@@ -11,6 +11,7 @@
 
 namespace think\model;
 
+use think\Exception;
 use think\Model;
 
 class Pivot extends Model
@@ -28,8 +29,12 @@ class Pivot extends Model
      * @param  Model         $parent 上级模型
      * @param  string        $table 中间数据表名
      */
-    public function __construct($data = [], Model $parent = null, $table = '')
+    public function __construct($data = [], $parent = null, $table = '')
     {
+        if (!is_null($parent) && !($parent instanceof Model)) {
+            throw new Exception('parent model must extends: \think\Model');
+        }
+        
         $this->parent = $parent;
 
         if (is_null($this->name)) {


### PR DESCRIPTION
多对多关联，中间表模型：
```
<?php
namespace app\index\model;

use think\model\Pivot;

class Access extends Pivot
{
    protected $autoWriteTimestamp = true;
}
```
控制器依赖注入：
```
<?php
namespace app\index\controller;

use app\index\model\Access ;

class Index
{
    public function hello(Access $access)
    {
        
    }
}
```
报错：
```
[0] ThrowableError in Container.php line 439
致命错误: Cannot instantiate abstract class think\Model
```