### PR TITLE
定义模型时hasMany($model, $foreignKey, $localKey)有三个参数，这里getPk()会使$localKey无效

### DIFF
--- a/library/think/model/relation/HasMany.php
+++ b/library/think/model/relation/HasMany.php
@@ -195,7 +195,7 @@ class HasMany extends Relation
         }
 
         return $this->query
-            ->whereExp($this->foreignKey, '=' . $this->parent->getTable() . '.' . $this->parent->getPk())
+            ->whereExp($this->foreignKey, '=' . $this->parent->getTable() . '.' . $this->localKey)
             ->fetchSql()
             ->$aggregate($field);
     }

--- a/library/think/model/relation/HasOne.php
+++ b/library/think/model/relation/HasOne.php
@@ -88,7 +88,7 @@ class HasOne extends OneToOne
         }
 
         return $this->query
-            ->whereExp($this->foreignKey, '=' . $this->parent->getTable() . '.' . $this->parent->getPk())
+            ->whereExp($this->foreignKey, '=' . $this->parent->getTable() . '.' . $this->localKey)
             ->fetchSql()
             ->$aggregate($field);
     }


### PR DESCRIPTION
举个栗子
ModelA extends Model {
protected $pk ="id";
public function b() {
return $this->hasMany("ModelB", "extra_aid", "extra_id");
}
}

ModelB extends Model {
protected $pk = "id";
}

$modelA = new ModelA;
$sql = $modelA->withCount("b")->fetchSql(true)->select();

这时候并不会按照理想的给出 b.extra_aid = a.extra_id
而是给出了b.extra_aid = a.id

所以我觉着这儿有问题。。
