### PR TITLE
保证数据转换的 Conversion->append 数组可用 #1203

### DIFF
--- a/library/think/model/concern/Conversion.php
+++ b/library/think/model/concern/Conversion.php
@@ -163,7 +163,7 @@ trait Conversion
         }
 
         // 追加属性（必须定义获取器）
-        if (!empty($this->append)) {
+        if (!empty($this->append) && is_array($this->append)) {
             foreach ($this->append as $key => $name) {
                 if (is_array($name)) {
                     // 追加关联对象属性


### PR DESCRIPTION
相关issue:[https://github.com/top-think/framework/issues/1203](https://github.com/top-think/framework/issues/1203)

类 `think\model\concern\Conversion` 的函数 
```
public function append(array $append = [], $override = false)
```
 中允许 `append` 被覆盖，它可能不是预设的数据类型，然后在 `toArray` 没有再校验，导致可能引起的 `Invalid argument supplied for foreach()` 错误。