### PR TITLE
改进域名拼接的判断

### DIFF
--- a/library/think/Url.php
+++ b/library/think/Url.php
@@ -316,7 +316,7 @@ class Url
                     }
                 }
             }
-        } elseif (0 !== strpos($domain, $rootDomain)) {
+        } elseif (0 !== strpos($domain, $rootDomain) && false === strpos($domain, '.')) {
             $domain .= '.' . $rootDomain;
         }
 


### PR DESCRIPTION
相关issue:[https://github.com/top-think/framework/issues/1453](https://github.com/top-think/framework/issues/1453)

改进后的仍存在问题。如果域名是 `www.comdev.com` 会得到 `http://www.comdev.com.comdev.com/` 。我似乎明白为何要判断 `.` 的存在的，因为需要考虑根域名。该PR修复，以下域名均通过测试：
```
127.0.0.1
localhost
local.local
local.local.local
comdev.com
www.comdev.com
com.local.com
```