### PR TITLE
修复自定义场景验证remove规则异常

### DIFF
--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -331,10 +331,10 @@ class Validate
      * 移除某个字段的验证规则
      * @access public
      * @param  string|array  $field  字段名
-     * @param  mixed         $rule   验证规则 true 移除所有规则
+     * @param  mixed         $rule   验证规则 null 移除所有规则
      * @return $this
      */
-    public function remove($field, $rule = true)
+    public function remove($field, $rule = null)
     {
         if (is_array($field)) {
             foreach ($field as $key => $rule) {


### PR DESCRIPTION
[https://github.com/top-think/framework/issues/1052](https://github.com/top-think/framework/issues/1052)

对于移除规则原本设计是 `true` 移除所有规则，但这会使的在 `Validate->checkItem` 中的 
`elseif (isset($this->remove[$field]) && in_array($info, $this->remove[$field])) {`
发生异常。