### PR TITLE
修复Lang未使用facade方式调用

### DIFF
--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -548,7 +548,7 @@ class Validate
                 if (!empty($msg[$i])) {
                     $message = $msg[$i];
                     if (is_string($message) && strpos($message, '{%') === 0) {
-                        $message = Lang::get(substr($message, 2, -1));
+                        $message = facade\Lang::get(substr($message, 2, -1));
                     }
                 } else {
                     $message = $this->getRuleMsg($field, $title, $info, $rule);


### PR DESCRIPTION
在 `think\Validate.php` 中存在调用方式的错误。