### PR TITLE
添加buildSaveName中自动补全扩展名的选项

### DIFF
--- a/library/think/File.php
+++ b/library/think/File.php
@@ -403,10 +403,6 @@ class File extends SplFileObject
             $savename = $this->getInfo('name');
         }
 
-        if (!strpos($savename, '.')) {
-            $savename .= '.' . pathinfo($this->getInfo('name'), PATHINFO_EXTENSION);
-        }
-
         return $savename;
     }
 

--- a/library/think/File.php
+++ b/library/think/File.php
@@ -393,7 +393,7 @@ class File extends SplFileObject
      * @param  string|bool   $savename    保存的文件名 默认自动生成
      * @return string
      */
-    protected function buildSaveName($savename)
+    protected function buildSaveName($savename, $auto_ext = true)
     {
         if (true === $savename) {
             // 自动生成文件名
@@ -401,6 +401,10 @@ class File extends SplFileObject
         } elseif ('' === $savename || false === $savename) {
             // 保留原文件名
             $savename = $this->getInfo('name');
+        }
+
+        if ($auto_ext && false === strpos($savename, '.')) {
+            $savename .= '.' . pathinfo($this->getInfo('name'), PATHINFO_EXTENSION);
         }
 
         return $savename;


### PR DESCRIPTION
`think\File` 里有一个`buildSaveName()`方法，如果没出现扩展名，没必要生成一个扩展名。尊重开发者的意志。

相关issue:[https://github.com/top-think/think/issues/834](https://github.com/top-think/think/issues/834)