### PR TITLE
改进模板优化

### DIFF
--- a/library/think/Template.php
+++ b/library/think/Template.php
@@ -387,7 +387,7 @@ class Template
         }
 
         // 优化生成的php代码
-        $content = preg_replace('/\?>\s*<\?php\s(?!echo\b)/s', '', $content);
+        $content = preg_replace('/\?>\s*<\?php\s(?!echo\b|\bend)/s', '', $content);
 
         // 模板过滤输出
         $replace = $this->config['tpl_replace_string'];


### PR DESCRIPTION
这部分正则是想将连续的php标签合并起来。但如果遇到 `<?php endif;` 或 `<?php endforeach;` 等，不要合并为好。

相关issue:[https://github.com/top-think/think/issues/696](https://github.com/top-think/think/issues/696)