### PR TITLE
改进strpos对子串是否存在的判断

### DIFF
--- a/library/think/Config.php
+++ b/library/think/Config.php
@@ -187,7 +187,7 @@ class Config implements \ArrayAccess
      */
     public function has($name)
     {
-        if (!strpos($name, '.')) {
+        if (false === strpos($name, '.')) {
             $name = $this->prefix . '.' . $name;
         }
 
@@ -225,7 +225,7 @@ class Config implements \ArrayAccess
      */
     public function get($name = null, $default = null)
     {
-        if ($name && !strpos($name, '.')) {
+        if ($name && false === strpos($name, '.')) {
             $name = $this->prefix . '.' . $name;
         }
 
@@ -272,7 +272,7 @@ class Config implements \ArrayAccess
     public function set($name, $value = null)
     {
         if (is_string($name)) {
-            if (!strpos($name, '.')) {
+            if (false === strpos($name, '.')) {
                 $name = $this->prefix . '.' . $name;
             }
 
@@ -314,7 +314,7 @@ class Config implements \ArrayAccess
      */
     public function remove($name)
     {
-        if (!strpos($name, '.')) {
+        if (false === strpos($name, '.')) {
             $name = $this->prefix . '.' . $name;
         }
 

--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -326,7 +326,7 @@ class Route
         // 支持多个域名使用相同路由规则
         $domainName = is_array($name) ? array_shift($name) : $name;
 
-        if ('*' != $domainName && !strpos($domainName, '.')) {
+        if ('*' != $domainName && false === strpos($domainName, '.')) {
             $domainName .= '.' . $this->request->rootDomain();
         }
 
@@ -344,7 +344,7 @@ class Route
         if (is_array($name) && !empty($name)) {
             $root = $this->request->rootDomain();
             foreach ($name as $item) {
-                if (!strpos($item, '.')) {
+                if (false === strpos($item, '.')) {
                     $item .= '.' . $root;
                 }
 
@@ -394,7 +394,7 @@ class Route
             $domain = $this->domain;
         } elseif (true === $domain) {
             return $this->bind;
-        } elseif (!strpos($domain, '.')) {
+        } elseif (false === strpos($domain, '.')) {
             $domain .= '.' . $this->request->rootDomain();
         }
 

--- a/library/think/console/command/optimize/Schema.php
+++ b/library/think/console/command/optimize/Schema.php
@@ -53,7 +53,7 @@ class Schema extends Command
             return;
         } elseif ($input->hasOption('table')) {
             $table = $input->getOption('table');
-            if (!strpos($table, '.')) {
+            if (false === strpos($table, '.')) {
                 $dbName = Db::getConfig('database');
             }
 

--- a/library/think/db/Connection.php
+++ b/library/think/db/Connection.php
@@ -361,7 +361,7 @@ abstract class Connection
 
         list($tableName) = explode(' ', $tableName);
 
-        if (!strpos($tableName, '.')) {
+        if (false === strpos($tableName, '.')) {
             $schema = $this->getConfig('database') . '.' . $tableName;
         } else {
             $schema = $tableName;

--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -1513,7 +1513,7 @@ class Query
             return $this;
         }
 
-        if (is_string($field) && !empty($this->options['via']) && !strpos($field, '.')) {
+        if (is_string($field) && !empty($this->options['via']) && false === strpos($field, '.')) {
             $field = $this->options['via'] . '.' . $field;
         }
 

--- a/library/think/model/concern/SoftDelete.php
+++ b/library/think/model/concern/SoftDelete.php
@@ -212,7 +212,7 @@ trait SoftDelete
             return false;
         }
 
-        if (!strpos($field, '.')) {
+        if (false === strpos($field, '.')) {
             $field = '__TABLE__.' . $field;
         }
 

--- a/library/think/response/Download.php
+++ b/library/think/response/Download.php
@@ -128,7 +128,7 @@ class Download extends Response
     {
         $this->name = $filename;
 
-        if ($extension && !strpos($filename, '.')) {
+        if ($extension && false === strpos($filename, '.')) {
             $this->name .= '.' . pathinfo($this->data, PATHINFO_EXTENSION);
         }
 


### PR DESCRIPTION
我确定这是个隐患。注意到，字符串位置是从0开始，而不是从1开始的。如果没找到 `needle`，将返回 FALSE。

来自官网的提醒：

> Warning 此函数可能返回布尔值 FALSE，但也可能返回等同于 FALSE 的非布尔值。请阅读 布尔类型章节以获取更多信息。应使用 === 运算符来测试此函数的返回值。

详见:[http://php.net/manual/zh/function.strpos.php](http://php.net/manual/zh/function.strpos.php)

比如下载文件`think\response\Download` 中函数 `name` 有个补全扩展名的：
```
if ($extension && !strpos($filename, '.')) {
    $this->name .= '.' . pathinfo($this->data, PATHINFO_EXTENSION);
}
```
如果下载的文件形如是 `.gitignore` 点开头的文件，则会变成 `..gitignore` 。

本 PR 将 `!strpos` 替换成 `false === strpos` ，已考虑兼容，不会出现影响兼容性的更新。