### PR TITLE
定义路由时自动补充默认模块或控制器

### DIFF
--- a/library/think/route/RuleGroup.php
+++ b/library/think/route/RuleGroup.php
@@ -13,6 +13,7 @@ namespace think\route;
 
 use think\Container;
 use think\Exception;
+use think\facade\Config;
 use think\Request;
 use think\Response;
 use think\Route;
@@ -436,6 +437,13 @@ class RuleGroup extends Rule
             $name = $rule[0];
             $rule = $rule[1];
         } elseif (is_string($route)) {
+            $route_split = explode('/', $route);
+            if (1 == count($route_split)) {
+                $route = Config::get('default_module') . '/' . Config::get('default_controller') . '/' . $route;
+            }else if (2 == count($route_split)) {
+                $route = Config::get('default_module') . '/' . $route;
+            }
+            unset($route_split);
             $name = $route;
         } else {
             $name = null;

--- a/library/think/route/RuleGroup.php
+++ b/library/think/route/RuleGroup.php
@@ -440,7 +440,7 @@ class RuleGroup extends Rule
             $route_split = explode('/', $route);
             if (1 == count($route_split)) {
                 $route = Config::get('default_module') . '/' . Config::get('default_controller') . '/' . $route;
-            }else if (2 == count($route_split)) {
+            } else if (2 == count($route_split)) {
                 $route = Config::get('default_module') . '/' . $route;
             }
             unset($route_split);


### PR DESCRIPTION
相关issue: #1499 

定义路由时自动补充默认模块或控制器，使得 `Route::get('test', 'index/test');` 与 `Route::get('test', 'index/index/test');` 行为一致。