### PR TITLE
建议db()助手函数默认不强制重新连接;

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -280,7 +280,7 @@ if (!function_exists('db')) {
      * @param bool          $force 是否强制重新连接
      * @return \think\db\Query
      */
-    function db($name = '', $config = [], $force = true)
+    function db($name = '', $config = [], $force = false)
     {
         return Db::connect($config, $force)->name($name);
     }


### PR DESCRIPTION
```
Db::startTrans();
$user = User::create($data);
// 这里事务是不能正常工作的，因为db助手默认重新连接，导致很多不熟悉这点的会踩到坑。
// 需要这样才能提交事务:
// db('profile', [], false)->insert(['uid' => $user['id']]);
db('profile')->insert(['uid' => $user['id']]);
DB::commit();
```