### PR TITLE
修复orderRaw异常

### DIFF
--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -3567,7 +3567,7 @@ class Query
                 $options['order'] = explode(',', $options['order']);
             }
             foreach ($options['order'] as $key => $val) {
-                if (is_numeric($key)) {
+                if (is_numeric($key) && is_string($val)) {
                     if (strpos($val, ' ')) {
                         list($field, $sort) = explode(' ', $val);
                         if (array_key_exists($field, $options['map'])) {


### PR DESCRIPTION
#1512 

复现方式：
```
Db::view('user', 'id,name')->where('id','<',10)->orderRaw('RAND()')->select();
```
这是因为`orderRaw`会创建Expression对象，然后在 `db\Query.php` 的 parseView 函数中没处理好。使用 `->order(new Expression(...))` 也会引发这个异常。