### PR TITLE
修复默认返回类型为json时，简洁模式的bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,35 +1,35 @@
 {
-    "name": "topthink/framework",
-    "description": "the new thinkphp framework",
-    "type": "think-framework",
-    "keywords": [
-        "framework",
-        "thinkphp",
-        "ORM"
-    ],
-    "homepage": "http://thinkphp.cn/",
-    "license": "Apache-2.0",
-    "authors": [
-        {
-            "name": "liu21st",
-            "email": "liu21st@gmail.com"
-        },
-        {
-            "name": "yunwuxin",
-            "email": "448901948@qq.com"
-        }
-    ],
-    "require": {
-        "php": ">=5.6.0",
-        "topthink/think-installer": "2.*"
+  "name": "shuliuzhenhua/framework",
+  "description": "the new thinkphp framework",
+  "type": "think-framework",
+  "keywords": [
+    "framework",
+    "thinkphp",
+    "ORM"
+  ],
+  "homepage": "http://thinkphp.cn/",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "liu21st",
+      "email": "liu21st@gmail.com"
     },
-    "require-dev": {
-        "phpunit/phpunit": "^5.0|^6.0",
-        "johnkary/phpunit-speedtrap": "^1.0",
-        "mikey179/vfsStream": "~1.6",
-        "phploc/phploc": "2.*",
-        "sebastian/phpcpd": "2.*",
-        "squizlabs/php_codesniffer": "2.*",
-        "phpdocumentor/reflection-docblock": "^2.0"
+    {
+      "name": "yunwuxin",
+      "email": "448901948@qq.com"
     }
+  ],
+  "require": {
+    "php": ">=5.6.0",
+    "topthink/think-installer": "2.*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^5.0|^6.0",
+    "johnkary/phpunit-speedtrap": "^1.0",
+    "mikey179/vfsStream": "~1.6",
+    "phploc/phploc": "2.*",
+    "sebastian/phpcpd": "2.*",
+    "squizlabs/php_codesniffer": "2.*",
+    "phpdocumentor/reflection-docblock": "^2.0"
+  }
 }

--- a/library/think/Paginator.php
+++ b/library/think/Paginator.php
@@ -412,13 +412,22 @@ abstract class Paginator implements ArrayAccess, Countable, IteratorAggregate, J
             $total = null;
         }
 
-        return [
-            'total'        => $total,
-            'per_page'     => $this->listRows(),
-            'current_page' => $this->currentPage(),
-            'last_page'    => $this->lastPage,
-            'data'         => $this->items->toArray(),
-        ];
+        if ($this->simple) {
+            return [
+                'per_page'     => $this->listRows,
+                'current_page' => $this->currentPage,
+                'has_more'     => $this->hasMore,
+                'data'         => $this->items->toArray(),
+            ];
+        } else {
+            return [
+                'total'        => $this->total,
+                'per_page'     => $this->listRows,
+                'current_page' => $this->currentPage,
+                'last_page'    => $this->lastPage,
+                'data'         => $this->items->toArray(),
+            ];
+        }
     }
 
     /**
@@ -441,5 +450,4 @@ abstract class Paginator implements ArrayAccess, Countable, IteratorAggregate, J
 
         return $result;
     }
-
 }


### PR DESCRIPTION
当在 app 配置文件中返回的数据格式为 json 时简洁模式会失效