### PR TITLE
FIX：当使用complex缓存的时候，通过store方法选择驱动，提供给connect的参数类型错误

### DIFF
--- a/src/think/Cache.php
+++ b/src/think/Cache.php
@@ -111,12 +111,13 @@ class Cache implements CacheItemPoolInterface
      * 切换缓存类型 需要配置 cache.type 为 complex
      * @access public
      * @param  string $name 缓存标识
+     * @param  bool          $force    强制更新
      * @return Driver
      */
-    public function store(string $name = ''): Driver
+    public function store(string $name = '', $force = false): Driver
     {
         if ('' !== $name && 'complex' == $this->config['type']) {
-            return $this->connect($this->config[$name], strtolower($name));
+            return $this->connect($this->config[$name], $force);
         }
 
         return $this->init();


### PR DESCRIPTION
为 store 方法增加 $force 参数，并用于 $this->connect 调用