### PR TITLE
路由变量替换的地方改进性能

### DIFF
--- a/library/think/route/Rule.php
+++ b/library/think/route/Rule.php
@@ -722,13 +722,16 @@ abstract class Rule
 
         // 替换路由地址中的变量
         if (is_string($route) && !empty($matches)) {
-            foreach ($matches as $key => $val) {
-                if (false !== strpos($route, '<' . $key . '>')) {
-                    $route = str_replace('<' . $key . '>', $val, $route);
-                } elseif (false !== strpos($route, ':' . $key)) {
-                    $route = str_replace(':' . $key, $val, $route);
-                }
+            $search = [];
+            $replace = [];
+            foreach ($matches as $key => $value) {
+                $search[] = '<' . $key . '>';
+                $replace[] = $value;
+
+                $search[] = ':' . $key;
+                $replace[] = $value;
             }
+            $route = str_replace($search, $replace, $route);
         }
 
         // 解析额外参数


### PR DESCRIPTION
原来代码：
```php
1: foreach ($matches as $key => $val) {
2:                 if (false !== strpos($route, '<' . $key . '>')) {
3:                     $route = str_replace('<' . $key . '>', $val, $route);
4:                 } elseif (false !== strpos($route, ':' . $key)) {
5:                    $route = str_replace(':' . $key, $val, $route);
6:                }
7: }
```
设matches数组大小为n
str_replace替换某个字符串的时间复杂度为P
变量字符平均长度为k
route平均长度为m
第一行循环n次
如果第2行满足条件，则需要平均执行: `((m-k-2)/2)+P`
如果第4行满足条件，则第2行一定不满足条件，则需要平均执行：`(m-k-2)+[(m-k-1)/2]+P`
一共执行次数：`O1 = n*{[(m-k-2)/2]+P+(m-k-2)+[(m-k-1)/2]+P}`
strpos的源码：
https://github.com/php/php-src/blob/54dc07f3dc9fa2fcfeb2d2c6aebf79bd34ab041c/Zend/zend_operators.h#L170

str_replace的源码：
https://github.com/php/php-src/blob/67e0138c0dfd966624223911a0821f6c294ad1c6/ext/standard/string.c#L4267

新的代码：
```php
            $search = [];
            $replace = [];
            foreach ($matches as $key => $value) {
                $search[] = '<' . $key . '>';
                $replace[] = $value;

                $search[] = ':' . $key;
                $replace[] = $value;
            }
            $route = str_replace($search, $replace, $route);
```
初始化$search和$replace需要的赋值次数：`2n`
执行str_replace时的执行次数是`2nP`
一共执行次数: `O2 = 2n + 2np`

使O2<O1，有：
```php
2n + 2np < n*{[(m-k-2)/2]+P+(m-k-2)+[(m-k-1)/2]+P}

=>
m - k > 11/4
```

所以$route的长度大于变量名的长度3个字符性能就会更好了，字符串批量替换用更多C代码执行，性能或许也能更高。