### PR TITLE
修复某些情况下生成路由的正则规则错误的BUG

### DIFF
--- a/library/think/route/Rule.php
+++ b/library/think/route/Rule.php
@@ -1001,7 +1001,7 @@ abstract class Rule
             }
         }
 
-        $regex = str_replace($match, $replace, $rule);
+        $regex = str_replace(array_unique($match), $replace, $rule);
         $regex = str_replace([')?/', ')/', ')?-', ')-', '\\\\/'], [')\/', ')\/', ')\-', ')\-', '\/'], $regex);
 
         if (isset($hasSlash)) {

--- a/library/think/route/Rule.php
+++ b/library/think/route/Rule.php
@@ -1001,7 +1001,7 @@ abstract class Rule
             }
         }
 
-        $regex = str_replace(array_unique($match), $replace, $rule);
+        $regex = str_replace(array_unique($match), array_unique($replace), $rule);
         $regex = str_replace([')?/', ')/', ')?-', ')-', '\\\\/'], [')\/', ')\/', ')\-', ')\-', '\/'], $regex);
 
         if (isset($hasSlash)) {


### PR DESCRIPTION
当pathinfo分隔符不是默认的/;
并且路由路由表达式中含有相同的路径;
并且路由表达式中中含有动态变量;
例如：
pathinfo分隔符：-
路由：Route::get('test/test/:abc', 'index/index');
访问：http://127.0.0.1:8000/test-test-test
会报404模块不存在:test
原因：/library/think/route/Rule.php#1004行在使用str_replace进行替换时会多次替换导致正则表达式错误。
解决：对查找和替换的数组进行去重