### PR TITLE
修复模型追加关联对象属性错误

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -887,7 +887,15 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 if (is_array($name)) {
                     // 追加关联对象属性
                     $relation   = $this->getAttr($key);
-                    $item[$key] = $relation->append($name)->toArray();
+                    if (!empty($relation)) {
+                        if (is_array($relation)) {
+                            $item[$key] = collection($relation)->append($name)->toArray();
+                        } else {
+                            $item[$key] = $relation->append($name)->toArray();
+                        }
+                    } else {
+                        $item[$key] = is_array($relation) ? [] : null;
+                    }
                 } elseif (strpos($name, '.')) {
                     list($key, $attr) = explode('.', $name);
                     // 追加关联对象属性


### PR DESCRIPTION
出现情况：
1.一对一关联时，当不存在关联属性时报错
2.一对多关联时，有没有数据都会报错