### PR TITLE
修复非80端口场景下路由生成的url中未携带端口号的BUG.

### DIFF
--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -137,7 +137,7 @@ class Route
         $this->request = $app['request'];
         $this->config  = $config;
 
-        $this->host = $this->request->host(true) ?: $config['app_host'];
+        $this->host = $this->request->host() ?: $config['app_host'];
 
         $this->setDefaultDomain();
     }


### PR DESCRIPTION
服务器端口为8080.

`route.php`中代码:
```php
Route:;get('about', 'index/About/index');
```

模板文件中代码:
```html
<a href="{:url('index/About/index', [], true, true)}">关于</a>
```

生成的url地址如下:
```html
<a href="http://xx.com/about">关于</a>
```

修改`library/think/Route.php`之后生成的url地址如下:
```html
<a href="http://xx.com:8080/about">关于</a>
```