### PR TITLE
修复自定义上传验证，检测文件大小

### DIFF
--- a/library/think/File.php
+++ b/library/think/File.php
@@ -300,7 +300,7 @@ class File extends SplFileObject
      */
     public function checkSize($size)
     {
-        if ($this->getSize() > $size) {
+        if ($this->getSize() > (int) $size) {
             $this->error = 'filesize not match';
             return false;
         }


### PR DESCRIPTION
自定义验证文件大小 验证时为字符串 无法比较
![tim 20190118110307](https://user-images.githubusercontent.com/24369905/51363136-a0579880-1b11-11e9-8617-5eb5c1b3fbe7.jpg)
![6cwo0 8 ox3z7 pn i r4b](https://user-images.githubusercontent.com/24369905/51363138-a188c580-1b11-11e9-8ebd-572253ba2300.png)
