### PR TITLE
自动生成模块支持二级控制器

### DIFF
--- a/library/think/Build.php
+++ b/library/think/Build.php
@@ -152,8 +152,21 @@ class Build
                 // 生成相关MVC文件
                 foreach ($file as $val) {
                     $val      = trim($val);
-                    $filename = $modulePath . $path . DIRECTORY_SEPARATOR . $val . ($suffix ? ucfirst($path) : '') . '.php';
-                    $space    = $namespace . '\\' . ($module ? $module . '\\' : '') . $path;
+                    // 多级控制器判断
+                    $lv = '';
+                    if ($path == 'controller' || $path == 'view') {
+                        if (strpos($val, '.') !== false) {
+                            list($lv, $val) = explode('.', $val);
+                        }
+                    }
+
+                    if (!empty($lv)) {
+                        $filename = $modulePath . $path . DIRECTORY_SEPARATOR . $lv . DIRECTORY_SEPARATOR . $val . ($suffix ? ucfirst($path) : '') . '.php';
+                        $space    = $namespace . '\\' . ($module ? $module . '\\' : '') . $path . '\\' .$lv;
+                    } else {
+                        $filename = $modulePath . $path . DIRECTORY_SEPARATOR . $val . ($suffix ? ucfirst($path) : '') . '.php';
+                        $space    = $namespace . '\\' . ($module ? $module . '\\' : '') . $path;
+                    }
                     $class    = $val . ($suffix ? ucfirst($path) : '');
                     switch ($path) {
                         case 'controller': // 控制器
@@ -163,7 +176,7 @@ class Build
                             $content = "<?php\nnamespace {$space};\n\nuse think\Model;\n\nclass {$class} extends Model\n{\n\n}";
                             break;
                         case 'view': // 视图
-                            $filename = $modulePath . $path . DIRECTORY_SEPARATOR . $val . '.html';
+                            $filename = $modulePath . $path . DIRECTORY_SEPARATOR . ($lv ? $lv . DIRECTORY_SEPARATOR : '') . $val . '.html';
                             $this->checkDirBuild(dirname($filename));
                             $content = '';
                             break;


### PR DESCRIPTION
自动生成模块配置如下：
'admin'     => [
        '__file__'   => ['common.php'],
        '__dir__'    => ['controller/v1', 'model', 'view'],
        'controller' => ['v1.Index', 'v1.Login'],
        'model'      => ['Login', 'Index'],
        'view'       => ['v1.index/index'],
    ],
    'home'     => [
        '__file__'   => ['common.php'],
        '__dir__'    => ['controller', 'model', 'view'],
        'controller' => ['Index', 'Login'],
        'model'      => ['Login', 'Index'],
        'view'       => ['index/index'],
    ]
home模块正常生成，包含多级控制器的admin模块，控制器的命名空间以及类名生成有误，模板目录生成有误。
更改如上，可支持二级控制器正确生成，不采用多级控制器不受影响。