### PR TITLE
Update Route.php

### DIFF
--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -321,7 +321,7 @@ class Route
             if (self::$domain) {
                 self::$rules['domain'][self::$domain]['*'][$group]['rule'][] = ['rule' => $rule, 'route' => $route, 'var' => $vars, 'option' => $option, 'pattern' => $pattern];
             } else {
-                self::$rules['*'][$group]['rule'][] = ['rule' => $rule, 'route' => $route, 'var' => $vars, 'option' => $option, 'pattern' => $pattern];
+                self::$rules[$type][$group]['rule'][] = ['rule' => $rule, 'route' => $route, 'var' => $vars, 'option' => $option, 'pattern' => $pattern];
             }
         } else {
             if ('*' != $type && isset(self::$rules['*'][$rule])) {


### PR DESCRIPTION
BUG：路由分组中的情况下，以下两个路由地址都只指向第一个地址
Route::group('admin', function () {
    
    //测试接口1
    Route::rule('test/one', 'index/test_one', 'POST');

    //测试接口2
    Route::rule('test/two', 'index/test_two', 'POST');
});