### PR TITLE
Update Route.php

### DIFF
--- a/library/think/Route.php
+++ b/library/think/Route.php
@@ -1311,8 +1311,8 @@ class Route
      */
     private static function match($url, $rule, $pattern)
     {
-        $m2 = explode('/', $rule);
-        $m1 = explode('|', $url);
+        $m1 = explode('/', $rule);
+        $m2 = explode('|', $url);
 
         $var = [];
         foreach ($m2 as $key => $val) {


### PR DESCRIPTION
下面这种情况，第二个路由访问不到
Route::group('admin', function () {
    Route::rule('user', 'admin/user.UserInfo/userInfoAdd', 'POST');
    Route::rule('user/edit', 'admin/user.UserInfo/userInfoEdit', 'POST');
});
方案一：当前匹配路由和url 是循环rule，修改为循环url
方案二： 当前分组路由 放再self::$rules['*']  ，修改到对应的method 二位数组内