### PR TITLE
模型日期时间字段为任意空值时，格式化后的值必然为`null`

### DIFF
--- a/library/think/model/concern/TimeStamp.php
+++ b/library/think/model/concern/TimeStamp.php
@@ -53,7 +53,7 @@ trait TimeStamp
     protected function formatDateTime($format, $time = 'now', $timestamp = false)
     {
         if (empty($time)) {
-            return;
+            return $time;
         }
 
         if (false === $format) {


### PR DESCRIPTION
https://github.com/top-think/framework/blob/23ee67bedf81958c8ebc1ab8c1d059ddbd82f1c3/library/think/model/concern/TimeStamp.php#L53-L57

如当字段值为0时，判断结果也是空 ，导致取出的值总是为`null`，后续处理时易发生不可预知的错误。  
5.2 的代码也存在这个问题。  