### PR TITLE
5.2  Query:table('table') 报数据类型不匹配的错误

### DIFF
--- a/src/think/db/Connection.php
+++ b/src/think/db/Connection.php
@@ -487,10 +487,10 @@ abstract class Connection
     /**
      * 获取数据表的主键
      * @access public
-     * @param  string $tableName 数据表名
+     * @param  mixed $tableName 数据表名
      * @return string|array
      */
-    public function getPk(string $tableName)
+    public function getPk($tableName)
     {
         return $this->getTableInfo($tableName, 'pk');
     }
@@ -498,10 +498,10 @@ abstract class Connection
     /**
      * 获取数据表字段信息
      * @access public
-     * @param  string $tableName 数据表名
+     * @param  mixed $tableName 数据表名
      * @return array
      */
-    public function getTableFields(string $tableName): array
+    public function getTableFields($tableName): array
     {
         return $this->getTableInfo($tableName, 'fields');
     }
@@ -509,11 +509,11 @@ abstract class Connection
     /**
      * 获取数据表字段类型
      * @access public
-     * @param  string $tableName 数据表名
+     * @param  mixed $tableName 数据表名
      * @param  string $field    字段名
      * @return array|string
      */
-    public function getFieldsType(string $tableName, string $field = null)
+    public function getFieldsType($tableName, string $field = null)
     {
         $result = $this->getTableInfo($tableName, 'type');
 
@@ -527,10 +527,10 @@ abstract class Connection
     /**
      * 获取数据表绑定信息
      * @access public
-     * @param  string $tableName 数据表名
+     * @param  mixed $tableName 数据表名
      * @return array
      */
-    public function getFieldsBind(string $tableName): array
+    public function getFieldsBind($tableName): array
     {
         return $this->getTableInfo($tableName, 'bind');
     }

--- a/src/think/db/Query.php
+++ b/src/think/db/Query.php
@@ -250,9 +250,9 @@ class Query
      * 得到当前或者指定名称的数据表
      * @access public
      * @param  string $name 不含前缀的数据表名字
-     * @return string
+     * @return mixed
      */
-    public function getTable(string $name = ''): string
+    public function getTable(string $name = '')
     {
         if (empty($name) && isset($this->options['table'])) {
             return $this->options['table'];
@@ -272,7 +272,7 @@ class Query
     public function getTableFields($tableName = ''): array
     {
         if ('' == $tableName) {
-            $tableName = $this->options['table'] ?? $this->getTable();
+            $tableName = $this->getTable();
         }
 
         return $this->connection->getTableFields($tableName);
@@ -301,9 +301,7 @@ class Query
             return $this->options['field_type'];
         }
 
-        $tableName = $this->options['table'] ?? $this->getTable();
-
-        return $this->connection->getFieldsType($tableName);
+        return $this->connection->getFieldsType($this->getTable());
     }
 
     /**


### PR DESCRIPTION
```php
use \think\db\Query;
AdminGroup::where('id', 'in', function($query){
        $query->table('admin_user_group')->where('admin_user_id', 1)->field('admin_group_id');
})->field(['id', 'name'])->select();
```
以上代码会调用`Query::table()`方法设置`\think\db\Query->options['table']`
从代码逻辑来看`$options['table']`为string/array

异常问题:
当程序调用`\think\db\Query->getTable()`时因为返回类型是string,有可能会出现类型不匹配的错误

![image](https://user-images.githubusercontent.com/2341581/54841500-5efa8980-4d0a-11e9-94ec-97b9bc9d3b4f.png)

https://github.com/top-think/framework/blob/47713eaecb2ccdf01f22c7594f7fa152a65ef062/src/think/db/Query.php#L255-L264

类似问题的地方还有几处:
https://github.com/top-think/framework/blob/47713eaecb2ccdf01f22c7594f7fa152a65ef062/src/think/db/Connection.php#L504-L507

https://github.com/top-think/framework/blob/47713eaecb2ccdf01f22c7594f7fa152a65ef062/src/think/db/Connection.php#L516-L525

https://github.com/top-think/framework/blob/47713eaecb2ccdf01f22c7594f7fa152a65ef062/src/think/db/Connection.php#L493-L496

以上问题不知道是我使用姿势不对还是官方有意对`table`方法做调整. 

ps:
`Db:table('table')->find();`也会有类似的错误

pull request 我调整了几处代码供参考


