### PR TITLE
修正从环境配置中读取调试开关时强类型报错

### DIFF
--- a/src/think/App.php
+++ b/src/think/App.php
@@ -445,7 +445,7 @@ class App extends Container
     {
         // 应用调试模式
         if (!$this->appDebug) {
-            $this->appDebug = $this->env->get('app_debug', false);
+            $this->appDebug = (bool)$this->env->get('app_debug', false);
         }
 
         if (!$this->appDebug) {


### PR DESCRIPTION
`Env::get('app_debug', false)`返回的是字符型，`App::$appDebug`是布尔型，导致调用`App::isDebug()`方法时报错