### PR TITLE
修复make方法类型限制对Facade调用造成的干扰

### DIFF
--- a/src/think/Facade.php
+++ b/src/think/Facade.php
@@ -69,12 +69,12 @@ class Facade
     /**
      * 调用类的实例
      * @access public
-     * @param  string        $class          类名或者标识
+     * @param  mixed      $class          类名或者标识
      * @param  array|true    $args           变量
      * @param  bool          $newInstance    是否每次创建新的实例
      * @return object
      */
-    public static function make(string $class, $args = [], $newInstance = false)
+    public static function make($class, $args = [], $newInstance = false)
     {
         if (__CLASS__ != static::class) {
             return self::__callStatic('make', func_get_args());


### PR DESCRIPTION
```
use think\facade\Validate;
Validate::make($rule = [], $msg = []);
```
报错如下:
\think\Facade::make() must be of the type string, array given, called in