### PR TITLE
修复闭包查询是无法获取表信息的问题

### DIFF
--- a/src/think/db/Query.php
+++ b/src/think/db/Query.php
@@ -1310,7 +1310,7 @@ class Query
     protected function whereEq(string $field, $value): array
     {
         $where = [$field, '=', $value];
-        if ($this->getPk() == $field) {
+        if ($this->getModel() && $this->getPk() == $field) {
             $this->options['key'] = $value;
         }
 


### PR DESCRIPTION
```
use think\db\Query;
Model::where(function(Query $query){
        $query->where('id',1);
})->find();
```

Query->parseWhereItem() 中会调用whereEq()方法获取主键信息  报错