### PR TITLE
fix insertAll logic defect

### DIFF
--- a/library/think/db/builder/Mysql.php
+++ b/library/think/db/builder/Mysql.php
@@ -34,6 +34,11 @@ class Mysql extends Builder
      */
     public function insertAll($dataSet, $options = [], $replace = false)
     {
+        $dataSet = array_map(function ($data) {
+            ksort($data);
+            return $data;
+        }, $dataSet);
+        
         // 获取合法的字段
         if ('*' == $options['field']) {
             $fields = array_keys($this->query->getFieldsType($options['table']));


### PR DESCRIPTION
默认把传进去的第一组数据的键排序当成insert的顺序，当传入数据键排序不一致时，会插入错误数据