### PR TITLE
FIX SQL BUILDER BUG

### DIFF
--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -1014,9 +1014,6 @@ abstract class Builder
 
         // 分析并处理数据
         $data = $this->parseData($query, $options['data']);
-        if (empty($data)) {
-            return '';
-        }
 
         $fields = array_keys($data);
         $values = array_values($data);


### PR DESCRIPTION
某些场景下会设置空数据插入，假如data为空返回，则会导致数据插入失败