### PR TITLE
改进 Composer 自动加载

### DIFF
--- a/library/think/Loader.php
+++ b/library/think/Loader.php
@@ -287,7 +287,7 @@ class Loader
         // Composer 自动加载支持
         if (is_dir(VENDOR_PATH . 'composer')) {
             if (PHP_VERSION_ID >= 50600 && is_file(VENDOR_PATH . 'composer' . DS . 'autoload_static.php')) {
-                require VENDOR_PATH . 'composer' . DS . 'autoload_static.php';
+                require_once VENDOR_PATH . 'composer' . DS . 'autoload_static.php';
 
                 $declaredClass = get_declared_classes();
                 $composerClass = array_pop($declaredClass);


### PR DESCRIPTION
fix #1762
解决使用 Composer 进行依赖管理并使用 PHPUnit 进行单元测试时提示 Cannot declare class Composer\Autoload\ComposerStaticInit 错误