### PR TITLE
修复开启自动写入时间戳模式时，模型第二次save操作若表不存在时间戳字段会报错问题

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -532,10 +532,6 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
             $field = $this->field;
         } else {
             $field = array_merge($this->field, $append);
-
-            if ($this->autoWriteTimestamp) {
-                array_push($field, $this->createTime, $this->updateTime);
-            }
         }
 
         if ($this->disuse) {

--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -1514,11 +1514,11 @@ class Validate
             $scene = $this->currentScene;
         }
 
-        $this->only = $this->append = $this->remove = [];
-
         if (empty($scene)) {
             return;
         }
+
+        $this->only = $this->append = $this->remove = [];
 
         if (method_exists($this, 'scene' . $scene)) {
             call_user_func([$this, 'scene' . $scene]);

--- a/library/think/model/relation/HasMany.php
+++ b/library/think/model/relation/HasMany.php
@@ -266,11 +266,11 @@ class HasMany extends Relation
     /**
      * 批量保存当前关联数据对象
      * @access public
-     * @param  array $dataSet   数据集
+     * @param  array|\think\Collection $dataSet   数据集
      * @param  boolean $replace 是否自动识别更新和写入
      * @return array|false
      */
-    public function saveAll(array $dataSet, $replace = true)
+    public function saveAll($dataSet, $replace = true)
     {
         $result = [];
 


### PR DESCRIPTION
当我开启auto_timestamp，同一模型操作第二次save操作，会因为模型对应的表不存在create_time或update_time字段，而导致数据无法写入或更新