### PR TITLE
为 rule 属性添加 getter 以便于在取出时对其进行一些修改

### DIFF
--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -399,7 +399,7 @@ class Validate
 
         if (empty($rules)) {
             // 读取验证规则
-            $rules = $this->rule;
+            $rules = $this->getRules();
         }
 
         // 获取场景定义
@@ -1550,5 +1550,14 @@ class Validate
         array_push($args, lcfirst($method));
 
         return call_user_func_array([$this, 'is'], $args);
+    }
+    
+    /**
+     * 获取当前的验证规则
+     * @access protected
+     * @return array
+     */
+    protected function getRules(){
+        return $this->rule;
     }
 }

--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -1557,7 +1557,8 @@ class Validate
      * @access protected
      * @return array
      */
-    protected function getRules(){
+    protected function getRules()
+    {
         return $this->rule;
     }
 }


### PR DESCRIPTION
为 rule 属性添加 getter 以便于在取出时对其进行一些修改
比如，使用函数。
这样是可以的：
```php
protected $rule = [
        'num'     => 'require|integer|in:1,10,38,66,188,520,1314',
];
```
但是这样却是不被允许的。
```php
protected $rule = [
        'num'     => 'require|integer|in:' . env('NUMBER_RANGE'),
];
```
希望通过 getter 方法来对其进行改变。