### PR TITLE
修正Model子类中initialize()方法无法动态修改数据库配置

### DIFF
--- a/library/think/Model.php
+++ b/library/think/Model.php
@@ -161,7 +161,10 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
                 $this->name = substr($this->name, 0, -strlen($suffix));
             }
         }
-
+        
+        // 执行初始化操作
+        $this->initialize();
+        
         if (is_null($this->autoWriteTimestamp)) {
             // 自动写入时间戳
             $this->autoWriteTimestamp = $this->getQuery()->getConfig('auto_timestamp');
@@ -175,8 +178,6 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
         if (is_null($this->resultSetType)) {
             $this->resultSetType = $this->getQuery()->getConfig('resultset_type');
         }
-        // 执行初始化操作
-        $this->initialize();
     }
 
     /**


### PR DESCRIPTION
`
class ContentComment extends Model
{
    # 文章评论模型
    protected $connection = [];
    //自定义初始化
    protected function initialize()
    {
        parent::initialize();
        $this->connection = [
            'type'     => 'mysql', // 数据库类型
            'hostname' => hcEnv("ad", "DB_HOST"), // 服务器地址
            'database' => hcEnv("ad", "DB_DATABASE"), // 数据库名
            'username' => hcEnv("ad", "DB_USERNAME"), // 用户名
            'password' => hcEnv("ad", "DB_PASSWORD"), // 密码
            'hostport' => hcEnv("ad", "DB_PORT"), // 端口
            'prefix'   => hcEnv("ad", "DB_PREFIX"), // 数据库表前缀
        ];
    }
}

`
继承Model的子类 调用initialize()方法无法动态修改connection配置参数。
将initialize()方法提前到getQuery()则可以动态修改connection