### PR TITLE
修复validate规则里面出现二维数组时的错误

### DIFF
--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -519,7 +519,7 @@ class Validate
 
         if (isset($this->append[$field])) {
             // 追加额外的验证规则
-            $rules = array_unique(array_merge($rules, $this->append[$field]));
+            $rules = array_unique(array_merge($rules, $this->append[$field]), SORT_REGULAR);
         }
 
         $i      = 0;


### PR DESCRIPTION
当validate的rule出现类似['require', 'in'=>[1,2,3]]这种规则，array_unique默认是SORT_STRING规则进行去重，而数组无法转换为字符串，出现报错，SORT_REGULAR则保留原有类型进行去重