### PR TITLE
修复google浏览器跨域报错问题

### DIFF
--- a/src/think/middleware/AllowCrossDomain.php
+++ b/src/think/middleware/AllowCrossDomain.php
@@ -23,6 +23,7 @@ class AllowCrossDomain
 {
     protected $header = [
         'Access-Control-Allow-Origin'  => '*',
+        'Access-Control-Allow-Credentials' => 'true',
         'Access-Control-Allow-Methods' => 'GET, POST, PATCH, PUT, DELETE',
         'Access-Control-Allow-Headers' => 'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, X-Requested-With',
     ];
@@ -39,6 +40,12 @@ class AllowCrossDomain
     {
         $header = !empty($header) ? array_merge($this->header, $header) : $this->header;
 
+        $http_origin = $request->header('origin');
+
+        if ($http_origin && preg_match('/.*?'.config('cookie.domain').'/i', $http_origin)) {
+            $header['Access-Control-Allow-Origin'] = $http_origin;
+        }
+        
         if ($request->method(true) == 'OPTIONS') {
             return Response::create()->code(204)->header($header);
         }


### PR DESCRIPTION
添加Access-Control-Allow-Credentials并设置为true
新版浏览器对 Access-Control-Allow-Origin 设置为 * 通配符也进行报错
修改根据cookie域名 实现动态多域名跨域