### PR TITLE
注释完善

### DIFF
--- a/src/think/File.php
+++ b/src/think/File.php
@@ -103,7 +103,6 @@ class File extends SplFileObject
     /**
      * 获取上传文件的信息
      * @access public
-     * @param  string   $name
      * @return array
      */
     public function getInfo(): array


### PR DESCRIPTION
File::getInfo()方法已取消参数传入