### PR TITLE
修复Query getPk 方法判断table字段是否存在问题

### DIFF
--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -1952,7 +1952,7 @@ class Query
         if (!empty($this->pk)) {
             $pk = $this->pk;
         } else {
-            $pk = $this->getTableInfo(is_array($options) ? $options['table'] : $options, 'pk');
+            $pk = $this->getTableInfo(is_array($options) && isset($options['table']) ? $options['table'] : $options, 'pk');
         }
         return $pk;
     }


### PR DESCRIPTION
Query的getPk方法只是判断$options是否是array，然后取$options['table']的值，此处应增加判断$options是否存在’table‘的key再取$options['table']的值