### PR TITLE
防止一些带有特殊字符的url，导致正则表达式报错

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ Thumbs.db
 /phpunit.xml
 /.idea
 /.vscode
+/.settings
+.buildpath
+.project

--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -724,10 +724,10 @@ class Request
                 $this->path = $pathinfo;
             } elseif ($suffix) {
                 // 去除正常的URL后缀
-                $this->path = preg_replace('/\.(' . ltrim($suffix, '.') . ')$/i', '', $pathinfo);
+                $this->path = preg_replace('/\.(' . preg_quote(ltrim($suffix, '.')) . ')$/i', '', $pathinfo);
             } else {
                 // 允许任何后缀访问
-                $this->path = preg_replace('/\.' . $this->ext() . '$/i', '', $pathinfo);
+                $this->path = preg_replace('/\.' . preg_quote($this->ext()) . '$/i', '', $pathinfo);
             }
         }
 


### PR DESCRIPTION
例如这样的url
https://xxxx/w00tw00t.at.blackhats.romanian.anti-sec:)
右括号在正则表达式中有特殊含义，会导致代码报错