### PR TITLE
多应用模式下，支持在具体应用内配置服务

### DIFF
--- a/src/think/Http.php
+++ b/src/think/Http.php
@@ -381,6 +381,13 @@ class Http
                 if (is_file($appPath . 'provider.php')) {
                     $this->app->bind(include $appPath . 'provider.php');
                 }
+
+                if (is_file($appPath . 'service.php')) {
+                    $services = include $appPath . 'service.php';
+                    foreach ($services as $service) {
+                        $this->app->register($service);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
多应用模式中，定义在具体应用内的service.php没有被识别。所以在Http.php中的loadApp方法中增加读取service.php并注册服务的实现。