### PR TITLE
增加Db类数组查询方式

### DIFF
--- a/src/think/db/concern/WhereQuery.php
+++ b/src/think/db/concern/WhereQuery.php
@@ -466,7 +466,13 @@ trait WhereQuery
                 if ($val instanceof Raw) {
                     $where[] = [$key, 'exp', $val];
                 } else {
-                    $where[] = is_null($val) ? [$key, 'NULL', ''] : [$key, is_array($val) ? 'IN' : '=', $val];
+                    if (is_null($val)) {
+                        $where[] = [$key, 'NULL', ''];
+                    } elseif (is_array($val)) {
+                        $where[] = [$key, $val[0], $val[1]];
+                    } else {
+                        $where[] = [$key, '=', $val];
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
支持类似以下的查询方式：传入数组作为查询条件
$map['status'] = ['in', [1,2]];
Db::table('think_user')->where($map)->select(); 