### PR TITLE
增加抛出异常代码

### DIFF
--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -1216,7 +1216,7 @@ class Request
         ];
 
         $msg = $fileUploadErrors[$error];
-        throw new Exception($msg);
+        throw new Exception($msg, $error);
     }
 
     /**


### PR DESCRIPTION
现在只抛出异常信息，不利于进行判断文件上传的具体错误。
增加抛出错误代码，方便根据错误代码来处理不同的错误。