### PR TITLE
直接获取pdo对象

### DIFF
--- a/src/think/db/PDOConnection.php
+++ b/src/think/db/PDOConnection.php
@@ -424,10 +424,10 @@ abstract class PDOConnection extends Connection
     public function getPdo()
     {
         if (!$this->linkID) {
-            return false;
+            $this->initConnect(true);
         }
 
-        return $this->linkID;
+        return $this->linkID ?: false;
     }
 
     /**


### PR DESCRIPTION
使用以下语句获取pdo对象时返回flase
`Db::connect()->getConnection()->getPdo();`
必须先执行类似下面数据库查询才能正确返回pdo对象
`Db::connect()->table('admin_user')->select();`