### PR TITLE
修复子目录的控制器解析错误

### DIFF
--- a/src/think/App.php
+++ b/src/think/App.php
@@ -576,7 +576,7 @@ class App extends Container
         $class = self::parseName(array_pop($array), 1);
         $path  = $array ? implode('\\', $array) . '\\' : '';
 
-        return $this->namespace . '\\' . $layer . '\\' . $path . $class;
+        return $this->namespace . '\\' . $layer . '\\' . lcfirst($path) . $class;
     }
 
     /**


### PR DESCRIPTION
/dir.test1/test2/?id=1
对应控制器应该为 app\controller\dir\Test1，目前是app\controller\Dir\Test1