### PR TITLE
解决`Swoole`下无法正常处理 Put、Json

### DIFF
--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -677,7 +677,7 @@ class Request
      */
     public function type(): string
     {
-        $accept = $this->server('HTTP_ACCEPT');
+        $accept = $this->header('HTTP_ACCEPT');
 
         if (empty($accept)) {
             return '';
@@ -998,7 +998,7 @@ class Request
         return $this->input($this->put, $name, $default, $filter);
     }
 
-    protected function getInputData($content): array
+    public function getInputData($content): array
     {
         if ($this->isJson()) {
             return (array) json_decode($content, true);
@@ -1816,7 +1816,7 @@ class Request
      */
     public function contentType(): string
     {
-        $contentType = $this->server('CONTENT_TYPE');
+        $contentType = $this->header('CONTENT_TYPE');
 
         if ($contentType) {
             if (strpos($contentType, ';')) {
@@ -2029,6 +2029,18 @@ class Request
     public function withPost(array $post)
     {
         $this->post = $post;
+        return $this;
+    }
+
+    /**
+     * 设置PUT数据
+     * @access public
+     * @param array $put
+     * @return $this
+     */
+    public function withPut(array $put)
+    {
+        $this->put = $put;
         return $this;
     }
 


### PR DESCRIPTION
修复后 Request 的构建调整为
```php
$request = $this->getApp()->request;
$queryStr = !empty($req->server['query_string']) ? '&' . $req->server['query_string'] : '';
$request = $request
    ->withHeader($header)
    ->withServer($server)
    ->withGet($req->get ?: [])
    ->withCookie($req->cookie ?: [])
    ->withInput($req->rawContent())
    ->withFiles($req->files ?: [])
    ->setBaseUrl($req->server['request_uri'])
    ->setUrl($req->server['request_uri'] . $queryStr)
    ->setPathinfo(ltrim($req->server['path_info'], '/'))
    ->withPost($req->post ?: $request->getInputData($request->getInput()))
    ->withPut($request->getInputData($request->getInput()));
```

https://github.com/NHZEX/tp-swoole/blob/1c146d5162cafaa8107304c522f4d3a2ae221f68/src/Worker/Http.php#L170