### PR TITLE
修复控制台表格渲染对多字节字符的兼容性

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
+        "ext-mbstring": "*",
         "league/flysystem": "^1.0",
         "league/flysystem-cached-adapter": "^1.0",
         "opis/closure": "^3.1",


### PR DESCRIPTION
修复前：
```
+----+-----------------+----------------+----------------+--------+
| id | genre           | name           | nick           | status |
+----+-----------------+----------------+----------------+--------+
| 2  | 超级管理员 | admin          | admin          | 正常 |
| 3  | 超级管理员 | admin123       | admin123       | 正常 |
| 4  | 超级管理员 | 123456         | 123456         | 正常 |
| 5  | 超级管理员 | ttttttt        | ttttttt2311    | 正常 |
| 7  | 超级管理员 | admin_6R3jDCTu | admin_6R3jDCTu | 正常 |
| 8  | 超级管理员 | admin_nkLrxsQF | admin_nkLrxsQF | 正常 |
+-----------------------------------------------------------------+
| test                                                            |
+-----------------------------------------------------------------+
| 1  | 1               | 1              | 1              | 1      |
+----+-----------------+----------------+----------------+--------+
```

修复后 （网页显示有一点变形，需要等宽字体）
```
+----+------------+----------------+----------------+--------+
| id | genre      | name           | nick           | status |
+----+------------+----------------+----------------+--------+
| 2  | 超级管理员 | admin          | admin          | 正常   |
| 3  | 超级管理员 | admin123       | admin123       | 正常   |
| 4  | 超级管理员 | 123456         | 123456         | 正常   |
| 5  | 超级管理员 | ttttttt        | ttttttt2311    | 正常   |
| 7  | 超级管理员 | admin_6R3jDCTu | admin_6R3jDCTu | 正常   |
| 8  | 超级管理员 | admin_nkLrxsQF | admin_nkLrxsQF | 正常   |
+------------------------------------------------------------+
| test                                                       |
+------------------------------------------------------------+
| 1  | 1          | 1              | 1              | 1      |
+----+------------+----------------+----------------+--------+
```