### PR TITLE
修改场景判断

### DIFF
--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -403,7 +403,9 @@ class Validate
         }
 
         // 获取场景定义
-        $this->getScene($scene);
+        if ($this->currentScene) {
+            $this->getScene($scene);
+        }
 
         foreach ($this->append as $key => $rule) {
             if (!isset($rules[$key])) {


### PR DESCRIPTION
今天使用的时候发现 $validate->only()->check()  这样没法使用，会被重置。刚看github上代码发现tp6.0改了 但是5.1这边没有改。