### PR TITLE
需先读取环境变量中调试模式的设置

### DIFF
--- a/src/think/App.php
+++ b/src/think/App.php
@@ -524,8 +524,9 @@ class App extends Container
     protected function debugModeInit(): void
     {
         // 应用调试模式
+        $this->appDebug = $this->env->get('app_debug') ? true : false;
+        
         if (!$this->appDebug) {
-            $this->appDebug = $this->env->get('app_debug') ? true : false;
             ini_set('display_errors', 'Off');
         }
 


### PR DESCRIPTION
否则设置不到调试模式