### PR TITLE
fix(session): 移除 session 驱动中 php-redis 的 del 方法别名

### DIFF
--- a/src/think/Session.php
+++ b/src/think/Session.php
@@ -275,7 +275,7 @@ class Session
 
                 $this->handler->write($sessionId, $data, $this->expire);
             } else {
-                $this->handler->delete($sessionId);
+                $this->handler->del($sessionId);
             }
         }
     }
@@ -405,7 +405,7 @@ class Session
         $result = $this->get($name);
 
         if ($result) {
-            $this->delete($name);
+            $this->del($name);
             return $result;
         }
     }
@@ -448,7 +448,7 @@ class Session
                 unset($items['__time__']);
 
                 foreach ($items as $item) {
-                    $this->delete($item);
+                    $this->del($item);
                 }
 
                 $this->set('__flash__', []);


### PR DESCRIPTION
## 概述

由于 php-redis 5 后续版本弃用了 Redis::delete()，修正 session 驱动调用 php-redis 的 delete 方法为 del 方法。

## 参考资料

> 引用自 https://github.com/phpredis/phpredis#del-delete-unlink
> Note: delete is an alias for del and will be removed in future versions of phpredis.

### Pull Request

> https://github.com/phpredis/phpredis/pull/1572

### Package Changelog

> https://pecl.php.net/package-changelog.php?package=redis&release=5.0.0