### PR TITLE
处理 think make 命令允许创建不合法模块。

### DIFF
--- a/library/think/console/command/Make.php
+++ b/library/think/console/command/Make.php
@@ -107,7 +107,7 @@ abstract class Make extends Command
         if(!empty($module)){
             if(!ctype_lower($module)){
                 $this->output->warning('[Warning]: Module name is only allowed to use lowercase!');
-                $module = strtolower($module);
+                $module = parse_name($module);
             }
             return $appNamespace . '\\' . $module;
         }

--- a/library/think/console/command/Make.php
+++ b/library/think/console/command/Make.php
@@ -104,7 +104,14 @@ abstract class Make extends Command
 
     protected function getNamespace($appNamespace, $module)
     {
-        return $module ? ($appNamespace . '\\' . $module) : $appNamespace;
+        if(!empty($module)){
+            if(!ctype_lower($module)){
+                $this->output->warning('[Warning]: Module name is only allowed to use lowercase!');
+                $module = strtolower($module);
+            }
+            return $appNamespace . '\\' . $module;
+        }
+        return $appNamespace;
     }
 
 }


### PR DESCRIPTION
在核心源代码中

> thinkphp/library/think/route/dispatch/Module.php:38
![image](https://user-images.githubusercontent.com/31845646/63582064-ed7d7a80-c5ca-11e9-846c-7d9ad5c5f154.png)

使用了

```php
strtolower($result[0] ?: $this->rule->getConfig('default_module'))
```

使创建的模块名变成了小写，但是在同文件第50 行进行判断时

> thinkphp/library/think/route/dispatch/Module.php:50
![image](https://user-images.githubusercontent.com/31845646/63582070-f3735b80-c5ca-11e9-844a-b0cb2ead4959.png)


直接对 `strtolower` 后的 $module 使用了 is_dir ,这个问题在 Windows 开发环境中并不容易被发现，

因为 Windows 下不区分大小写，但是在 Linux 下将会存在此问题。

使用 `think` 创建时 并没有进行相关提示或者自动处理。