### PR TITLE
改进运行服务命令，为其增加尝试启动运行服务功能

### DIFF
--- a/src/think/console/command/RunServer.php
+++ b/src/think/console/command/RunServer.php
@@ -19,6 +19,11 @@ use think\console\Output;
 
 class RunServer extends Command
 {
+    /**
+     * @var int 尝试启动服务次数
+     */
+    protected $tries = 10;
+    
     public function configure()
     {
         $this->setName('run')
@@ -51,7 +56,13 @@ class RunServer extends Command
         $output->writeln(sprintf('ThinkPHP Development server is started On <http://%s:%s/>', '0.0.0.0' == $host ? '127.0.0.1' : $host, $port));
         $output->writeln(sprintf('You can exit with <info>`CTRL-C`</info>'));
         $output->writeln(sprintf('Document root is: %s', $root));
-        passthru($command);
+        
+        passthru($command, $status);
+        if ($status && $this->tries > 0) {
+            $this->tries -= 1;
+            $input->setOption('port', $input->getOption('port') + 1);
+            $this->execute($input, $output);
+        }
     }
 
 }


### PR DESCRIPTION
改进运行服务命令，当端 8000 端口占用时，用其他端口尝试启动运行服务。