### PR TITLE
修正并发情况下，创建文件夹会提示文件夹存在的情况和Download功能中注释错误的问题。

### DIFF
--- a/library/think/File.php
+++ b/library/think/File.php
@@ -150,6 +150,7 @@ class File extends SplFileObject
      * @access protected
      * @param  string   $path    目录
      * @return boolean
+     * @throws \Exception
      */
     protected function checkPath($path)
     {
@@ -157,8 +158,15 @@ class File extends SplFileObject
             return true;
         }
 
-        if (mkdir($path, 0755, true)) {
-            return true;
+        try {
+            if (mkdir($path, 0755, true)) {
+                return true;
+            }
+        } catch (\Exception $e) {
+            if ($e->getMessage() === 'mkdir(): File exists') {
+                return true;
+            }
+            throw $e;
         }
 
         $this->error = ['directory {:path} creation failed', ['path' => $path]];

--- a/library/think/response/Download.php
+++ b/library/think/response/Download.php
@@ -91,7 +91,7 @@ class Download extends Response
     /**
      * 设置文件类型
      * @access public
-     * @param  string $filename 文件名
+     * @param  string mimeType 文件类型
      * @return $this
      */
     public function mimeType($mimeType)


### PR DESCRIPTION
当前端多次请求文件上传接口，后端使用$file->move($path)将文件存放到需要新建文件夹保存的地方时，部分文件上传会出现 `mkdir(): File exists` 的Warning。