### PR TITLE
解决对别名字段名字属性解析不正确的问题

### DIFF
--- a/src/think/Validate.php
+++ b/src/think/Validate.php
@@ -1616,7 +1616,7 @@ class Validate
                 $msg);
 
             if (strpos($msg, ':rule')) {
-                $msg = str_replace(':rule', (string) $rule, $msg);
+                $msg = str_replace(':rule', (string) isset($this->field[$rule]) ? $this->field[$rule] : $rule, $msg);
             }
         }
 


### PR DESCRIPTION
`$rule` 为字段规则名，当在 `$this->field` 中指定了其的别名时无法生效，故此解决此问题。

![image](https://user-images.githubusercontent.com/31845646/65301313-6f040080-dba9-11e9-897b-333cd4ac08e5.png)

图中  `finish_at` 已经指定为 `结束时间` ，但是在 error 信息并不能很好的显示为 `结束时间` 而是显示成了 `finish_at`,