### PR TITLE
解决静态调用验证规则时无法使用自定义验证的问题

### DIFF
--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -570,7 +570,7 @@ class Validate
                     $result = str_replace(':attribute', $title, $result);
 
                     if (strpos($result, ':rule') && is_scalar($rule)) {
-                        $msg = str_replace(':rule', (string) $rule, $result);
+                        $result = str_replace(':rule', (string) isset($this->field[$rule]) ? $this->field[$rule] : $rule, $result);
                     }
                 }
 

--- a/library/think/Validate.php
+++ b/library/think/Validate.php
@@ -208,7 +208,7 @@ class Validate
      */
     public static function make(array $rules = [], array $message = [], array $field = [])
     {
-        return new self($rules, $message, $field);
+        return new static($rules, $message, $field);
     }
 
     /**


### PR DESCRIPTION
- 解决静态调用验证规则时无法使用自定义验证的问题。
- 修复自定义错误信息 `:rule` 替换变量返回错误。