### PR TITLE
改进验证器在规则为数组时返回规则提示信息不会替换变量(:attribute,:rule)问题

### DIFF
--- a/src/think/Validate.php
+++ b/src/think/Validate.php
@@ -1602,6 +1602,11 @@ class Validate
             $msg = $this->lang->get($msg);
         }
 
+        // rule为一维数组时，将数组转为string
+        if (is_array($rule) && array_keys($rule) === range(0, count($rule) - 1) && count($rule) === count($rule, 1)) {
+            $rule = implode(',', $rule);
+        }
+
         if (is_scalar($rule) && false !== strpos($msg, ':')) {
             // 变量替换
             if (is_string($rule) && strpos($rule, ',')) {


### PR DESCRIPTION
改进验证器在规则为数组时返回规则提示信息不会替换变量(:attribute,:rule)问题
如 in/notIn 规则支持数组，若规则为数组时不会正常返回提示信息
