### PR TITLE
5.1 修复Builder.php parseDateTime方法格式化“1970-01-01 08:00:00"为原值而不是0的问题

### DIFF
--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -722,7 +722,7 @@ abstract class Builder
 
         if (isset($info)) {
             if (is_string($value)) {
-                $value = strtotime($value) ?: $value;
+                $value = strtotime($value) !== false ? strtotime($value) : $value;
             }
 
             if (preg_match('/(datetime|timestamp)/is', $info)) {


### PR DESCRIPTION
修复Builder.php parseDateTime方法格式化“1970-01-01 08:00:00"为原值而不是0的问题。