### PR TITLE
[6.0] 修复严格类型下 HttpException->$message 不能为 null

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -45,7 +45,7 @@ if (!function_exists('abort')) {
      * @param string           $message 错误信息
      * @param array            $header  参数
      */
-    function abort($code, string $message = null, array $header = [])
+    function abort($code, string $message = '', array $header = [])
     {
         if ($code instanceof Response) {
             throw new HttpResponseException($code);

--- a/src/think/exception/HttpException.php
+++ b/src/think/exception/HttpException.php
@@ -12,6 +12,8 @@ declare (strict_types = 1);
 
 namespace think\exception;
 
+use Exception;
+
 /**
  * HTTP异常
  */
@@ -20,7 +22,7 @@ class HttpException extends \RuntimeException
     private $statusCode;
     private $headers;
 
-    public function __construct(int $statusCode, string $message = null, \Exception $previous = null, array $headers = [], $code = 0)
+    public function __construct(int $statusCode, string $message = '', Exception $previous = null, array $headers = [], $code = 0)
     {
         $this->statusCode = $statusCode;
         $this->headers    = $headers;


### PR DESCRIPTION
修复调用 `abort(401)` 时报错 `Wrong parameters for think\exception\HttpException([string $message [, long $code [, Throwable $previous = NULL]]])`