### PR TITLE
避免时间戳相加整型溢出

### DIFF
--- a/src/think/cache/driver/File.php
+++ b/src/think/cache/driver/File.php
@@ -95,7 +95,7 @@ class File extends Driver
 
         if (false !== $content) {
             $expire = (int) substr($content, 8, 12);
-            if (0 != $expire && time() > filemtime($filename) + $expire) {
+            if (0 != $expire && time() - $expire > filemtime($filename)) {
                 //缓存过期删除缓存文件
                 $this->unlink($filename);
                 return;

--- a/src/think/session/driver/File.php
+++ b/src/think/session/driver/File.php
@@ -77,7 +77,7 @@ class File implements SessionHandlerInterface
         $now      = time();
 
         $files = $this->findFiles($this->config['path'], function (SplFileInfo $item) use ($lifetime, $now) {
-            return $now > $item->getMTime() + $lifetime;
+            return $now - $lifetime > $item->getMTime();
         });
 
         foreach ($files as $file) {


### PR DESCRIPTION
为避免溢出问题，应使用减法来代替。可参照项目中的其他地方的处理方式：

https://github.com/top-think/framework/blob/abaec0344bbd57671e29010d2d7a2c1d609861a4/src/think/session/driver/File.php#L150