### PR TITLE
增强中间件CheckRequestCache的实用性

### DIFF
--- a/src/think/middleware/CheckRequestCache.php
+++ b/src/think/middleware/CheckRequestCache.php
@@ -110,6 +110,10 @@ class CheckRequestCache
         $except = $this->config['request_cache_except'];
         $tag    = $this->config['request_cache_tag'];
 
+        if ($key instanceof \Closure) {
+            $key = call_user_func($key, $request);
+        }
+
         if (false === $key) {
             // 关闭当前缓存
             return;
@@ -121,9 +125,7 @@ class CheckRequestCache
             }
         }
 
-        if ($key instanceof \Closure) {
-            $key = call_user_func($key);
-        } elseif (true === $key) {
+        if (true === $key) {
             // 自动缓存功能
             $key = '__URL__';
         } elseif (strpos($key, '|')) {


### PR DESCRIPTION
1. 回调函数增加传递 `$request` 参数；
2. 回调函数率先运行，即以回调函数的反正值作为 `request_cache_key` 的值，然后走后续判断和替换逻辑。