### PR TITLE
完善跨域请求，可以支持多个域名

### DIFF
--- a/src/think/middleware/AllowCrossDomain.php
+++ b/src/think/middleware/AllowCrossDomain.php
@@ -33,6 +33,9 @@ class AllowCrossDomain
     public function __construct(Config $config)
     {
         $this->cookieDomain = $config->get('cookie.domain', '');
+        if(is_string($this->cookieDomain)) {
+            $this->cookieDomain = explode(',', $this->cookieDomain);
+        }
     }
 
     /**
@@ -50,9 +53,9 @@ class AllowCrossDomain
         if (!isset($header['Access-Control-Allow-Origin'])) {
             $origin = $request->header('origin');
 
-            if ($origin && ('' == $this->cookieDomain || strpos($origin, $this->cookieDomain))) {
+            if ($origin && (!empty($this->cookieDomain) && in_array($origin, $this->cookieDomain))) {
                 $header['Access-Control-Allow-Origin'] = $origin;
-            } else {
+            } else if(in_array('*', $this->cookieDomain)) {
                 $header['Access-Control-Allow-Origin'] = '*';
             }
         }


### PR DESCRIPTION
原来的设计只要允许了跨域就一定会给出一个Access-Control-Allow-Origin
但如果原始请求没有给出origin就会返回*
改进后的可以在允许的域名里面进行判定，如果没有则判定是否允许*