### PR TITLE
防止路由标识生成URL时生成空字符串

### DIFF
--- a/src/think/route/Url.php
+++ b/src/think/route/Url.php
@@ -469,8 +469,9 @@ class Url
                 $url .= $suffix . '?' . $vars . $anchor;
             } else {
                 foreach ($vars as $var => $val) {
+                    $val = (string) $val;
                     if ('' !== $val) {
-                        $url .= $depr . $var . $depr . urlencode((string) $val);
+                        $url .= $depr . $var . $depr . urlencode($val);
                     }
                 }
 


### PR DESCRIPTION
配置了 `'url_common_param'=>false` 时，对于：
```
url('test', ['name'=>'tom', 'desc'=>''])    生成：'/index.php/Index/test/name/tom.html'        // 正确
url('test', ['name'=>'tom', 'desc'=>null])  生成：'/index.php/Index/test/name/tom/desc/.html'  // 有误
url('test', ['name'=>'tom', 'desc'=>false]) 生成：'/index.php/Index/test/name/tom/desc/.html'  // 有误
``` 