### PR TITLE
完善跨域中间件的响应头部

### DIFF
--- a/src/think/middleware/AllowCrossDomain.php
+++ b/src/think/middleware/AllowCrossDomain.php
@@ -26,8 +26,8 @@ class AllowCrossDomain
 
     protected $header = [
         'Access-Control-Allow-Credentials' => 'true',
-        'Access-Control-Allow-Methods'     => 'GET, POST, PATCH, PUT, DELETE',
-        'Access-Control-Allow-Headers'     => 'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, X-Requested-With',
+        'Access-Control-Allow-Methods'     => 'GET, POST, PATCH, PUT, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers'     => 'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, X-CSRF-TOKEN, X-Requested-With',
     ];
 
     public function __construct(Config $config)


### PR DESCRIPTION
1. 中间件中处理了 `OPTIONS` 请求，所以它也是被允许的；
2. 添加csrf头部允许，`Request` 类里验证令牌取的是 `X-CSRF-TOKEN` ，所以这里设置这个值。