### PR TITLE
让中间件CheckRequestCache只访问一次临界区

### DIFF
--- a/src/think/middleware/CheckRequestCache.php
+++ b/src/think/middleware/CheckRequestCache.php
@@ -75,8 +75,8 @@ class CheckRequestCache
                 if (strtotime($request->server('HTTP_IF_MODIFIED_SINCE', '')) + $expire > $request->server('REQUEST_TIME')) {
                     // 读取缓存
                     return Response::create()->code(304);
-                } elseif ($this->cache->has($key)) {
-                    list($content, $header) = $this->cache->get($key);
+                } elseif ($hit = $this->cache->get($key)) {
+                    list($content, $header) = $hit;
 
                     return Response::create($content)->header($header);
                 }

--- a/src/think/middleware/CheckRequestCache.php
+++ b/src/think/middleware/CheckRequestCache.php
@@ -75,7 +75,7 @@ class CheckRequestCache
                 if (strtotime($request->server('HTTP_IF_MODIFIED_SINCE', '')) + $expire > $request->server('REQUEST_TIME')) {
                     // 读取缓存
                     return Response::create()->code(304);
-                } elseif ($hit = $this->cache->get($key)) {
+                } elseif (($hit = $this->cache->get($key)) !== null) {
                     list($content, $header) = $hit;
 
                     return Response::create($content)->header($header);


### PR DESCRIPTION
`cache` 的 `has` 方法会通过 `get` 形式获取，所以这边会访问两次临界区。如果驱动是文件缓存，就会读取两次文件。低概率情况下会发生，两次读取完成的时间差内，缓存正好过期，造成异常。

PR优化为只访问一次临界区。