### PR TITLE
增强高并发下session_id生成的唯一性

### DIFF
--- a/src/think/session/Store.php
+++ b/src/think/session/Store.php
@@ -118,7 +118,7 @@ class Store
      */
     public function setId($id = null): void
     {
-        $this->id = is_string($id) && strlen($id) === 32 ? $id : md5(microtime(true) . uniqid());
+        $this->id = is_string($id) && strlen($id) === 32 ? $id : md5(microtime(true) . uniqid('', true));
     }
 
     /**


### PR DESCRIPTION
来自 https://www.php.net/manual/zh/function.uniqid.php 中的描述：
>Warning 此函数不保证返回值的唯一性。 由于绝大多数系统使用 NTP 或者类似服务调整系统的时间，所以系统时间经常发生变化。 此外，进程/线程可能不会返回唯一的 ID。 用 more_entropy 来增加唯一性的概率。

因此加入 `more_entropy` 参数，使得唯一ID更具唯一性。