### PR TITLE
文件缓存驱动写文件时加锁

### DIFF
--- a/src/think/cache/driver/File.php
+++ b/src/think/cache/driver/File.php
@@ -176,7 +176,7 @@ class File extends Driver
         }
 
         $data   = "<?php\n//" . sprintf('%012d', $expire) . "\n exit();?>\n" . $data;
-        $result = file_put_contents($filename, $data);
+        $result = file_put_contents($filename, $data, LOCK_EX);
 
         if ($result) {
             clearstatcache();


### PR DESCRIPTION
参照于session文件写入时加锁：

https://github.com/top-think/framework/blob/3c01a4e9bcb401d109a9c098b9fbc53e5e447024/src/think/session/driver/File.php#L170-L173