### PR TITLE
修正 Request::remotePort 返回类型

### DIFF
--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -1794,11 +1794,11 @@ class Request
     /**
      * 当前请求 REMOTE_PORT
      * @access public
-     * @return string
+     * @return int
      */
-    public function remotePort(): string
+    public function remotePort(): int
     {
-        return $this->server('REMOTE_PORT', '');
+        return (int) $this->server('REMOTE_PORT', '');
     }
 
     /**


### PR DESCRIPTION
与 port 保持统一