### PR TITLE
修复memcache驱动inc函数重复添加前缀问题

### DIFF
--- a/src/think/cache/driver/Memcache.php
+++ b/src/think/cache/driver/Memcache.php
@@ -138,7 +138,7 @@ class Memcache extends Driver
 
         $key = $this->getCacheKey($name);
 
-        if ($this->has($key)) {
+        if ($this->handler->get($key)) {
             return $this->handler->increment($key, $step);
         }
 


### PR DESCRIPTION
`$key = getCacheKey($name)` 已为键添加了前缀，`has($key)` 会重新加一次，导致命中误判。可参考其他缓存驱动类中的inc方法。