### PR TITLE
修复中间件CheckRequestCache使用过期数据

### DIFF
--- a/src/think/middleware/CheckRequestCache.php
+++ b/src/think/middleware/CheckRequestCache.php
@@ -77,8 +77,9 @@ class CheckRequestCache
                     return Response::create()->code(304);
                 } elseif (($hit = $this->cache->get($key)) !== null) {
                     list($content, $header, $when) = $hit;
-                    if ($expire === null || $when + $expire > $request->server('REQUEST_TIME'))
+                    if ($expire === null || $when + $expire > $request->server('REQUEST_TIME')) {
                         return Response::create($content)->header($header);
+                    }
                 }
             }
         }

--- a/src/think/middleware/CheckRequestCache.php
+++ b/src/think/middleware/CheckRequestCache.php
@@ -76,9 +76,9 @@ class CheckRequestCache
                     // 读取缓存
                     return Response::create()->code(304);
                 } elseif (($hit = $this->cache->get($key)) !== null) {
-                    list($content, $header) = $hit;
-
-                    return Response::create($content)->header($header);
+                    list($content, $header, $when) = $hit;
+                    if ($expire === null || $when + $expire > $request->server('REQUEST_TIME'))
+                        return Response::create($content)->header($header);
                 }
             }
         }
@@ -91,7 +91,7 @@ class CheckRequestCache
             $header['Last-Modified'] = gmdate('D, d M Y H:i:s') . ' GMT';
             $header['Expires']       = gmdate('D, d M Y H:i:s', time() + $expire) . ' GMT';
 
-            $this->cache->tag($tag)->set($key, [$response->getContent(), $header], $expire);
+            $this->cache->tag($tag)->set($key, [$response->getContent(), $header, time()], $expire);
         }
 
         return $response;


### PR DESCRIPTION
相关issue：#2040

比如设置请求缓存有效期半小时，一会后，设置为 1 分钟。那么数据应该过期，而当前会继续使用旧数据返回。

PR中将保存时的时间戳也保存下来，并进行二次校验。