### PR TITLE
修正生成URL不传参数时，方法名为空#2063

### DIFF
--- a/src/think/route/Url.php
+++ b/src/think/route/Url.php
@@ -241,6 +241,8 @@ class Url
         } elseif (0 === strpos($url, '@')) {
             // 解析到控制器
             $url = substr($url, 1);
+        } elseif ('' === $url) {
+            $url = $request->controller() . '/' . $request->action();
         } else {
             $controller = $request->controller();
 


### PR DESCRIPTION
修正生成URL不传参数时，方法名为空#2063