### PR TITLE
修复中间件FormTokenCheck无法启用问题

### DIFF
--- a/src/think/middleware/FormTokenCheck.php
+++ b/src/think/middleware/FormTokenCheck.php
@@ -31,7 +31,7 @@ class FormTokenCheck
      * @param string  $token 表单令牌Token名称
      * @return Response
      */
-    public function handle(Request $request, Closure $next, string $token = '')
+    public function handle(Request $request, Closure $next, string $token = null)
     {
         $check = $request->checkToken($token ?: '__token__');
 


### PR DESCRIPTION
中间件FormTokenCheck启用后报错：

![20191021234643](https://user-images.githubusercontent.com/7546325/67221047-6aa75d80-f45d-11e9-8380-f91eddbfdb10.png)
