### PR TITLE
使用session_create_id生成id，保证唯一性

### DIFF
--- a/src/think/session/Store.php
+++ b/src/think/session/Store.php
@@ -118,7 +118,7 @@ class Store
      */
     public function setId($id = null): void
     {
-        $this->id = is_string($id) && strlen($id) === 32 ? $id : md5(microtime(true) . uniqid('', true));
+        $this->id = is_string($id) && strlen($id) === 32 ? $id : md5(microtime(true) . session_create_id());
     }
 
     /**


### PR DESCRIPTION
该函数php7.1开始支持，与tp6要求也是7.1，该函数专门返回不冲突的seesion id。 https://www.php.net/manual/en/function.session-create-id.php

>session_create_id() is used to create new session id for the current session. It returns collision free session id.