### PR TITLE
去掉重复代码

### DIFF
--- a/src/think/route/dispatch/Controller.php
+++ b/src/think/route/dispatch/Controller.php
@@ -102,9 +102,7 @@ class Controller extends Dispatch
                     throw new HttpException(404, 'method not exists:' . get_class($instance) . '->' . $action . '()');
                 }
 
-                $data = $this->app->invokeReflectMethod($instance, $reflect, $vars);
-
-                return $this->autoResponse($data);
+                return $this->app->invokeReflectMethod($instance, $reflect, $vars);
             });
     }
 


### PR DESCRIPTION
`think\route\Dispatch::run` 方法在调用 `$this->exec()` 后会执行 `$this->autoResponse($data)`

因此，在子类的 `exec` 中就没必须再调用一次 `$this->autoResponse` 了