### PR TITLE
php7.1开始 array_walk_recursive 就不消耗指针了

### DIFF
--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -1101,7 +1101,6 @@ class Request
 
         if (is_array($data)) {
             array_walk_recursive($data, [$this, 'filterValue'], $filter);
-            reset($data);
         } else {
             $this->filterValue($data, $name, $filter);
         }
@@ -1288,7 +1287,6 @@ class Request
 
         if (is_array($data)) {
             array_walk_recursive($data, [$this, 'filterValue'], $filter);
-            reset($data);
         } else {
             $this->filterValue($data, $name, $filter);
         }


### PR DESCRIPTION
php7.1+开始 array_walk_recursive 就不消耗指针了。见：https://bugs.php.net/bug.php?id=62607

所以PR仅是代码清理。