### PR TITLE
修复FileResponse的cookie空对象异常

### DIFF
--- a/src/think/Response.php
+++ b/src/think/Response.php
@@ -138,8 +138,9 @@ abstract class Response
                 header($name . (!is_null($val) ? ':' . $val : ''));
             }
         }
-
-        $this->cookie->save();
+        if ($this->cookie) {
+            $this->cookie->save();
+        }
 
         $this->sendData($data);
 


### PR DESCRIPTION
文档里的文件下载示例:
```
    	$file=  new \think\response\File('image.jpg');
        return $file->name('my.jpg');
```
Response类会在send中进行 `$this->cookie->save();` 操作。而 File 类中cookie属性未设置而造成异常。

其他 Response 的子类都有在构造函数里对cookie进行设置。File 类理论上也可以这么做。相应的文档里的示例也需要更新。

PR选择比较保守的修复方式。