### PR TITLE
修正异常页面的模板文件

### DIFF
--- a/src/tpl/think_exception.tpl
+++ b/src/tpl/think_exception.tpl
@@ -343,7 +343,7 @@ if (!function_exists('echo_value')) {
         <?php } ?>
     <?php } else { ?>
     <div class="exception">
-        <div class="info"><h1><?php echo htmlentities($traces[0]['message']); ?></h1></div>
+        <div class="info"><h1><?php echo htmlentities($message); ?></h1></div>
     </div>
     <?php } ?>
     


### PR DESCRIPTION
关闭调试模式时，仅有`$code`和`$message`变量，没有`$traces`变量