### PR TITLE
修改一个BUG，当使用验证类验证jpg结尾的图片报错问题

### DIFF
--- a/src/think/Validate.php
+++ b/src/think/Validate.php
@@ -1077,8 +1077,8 @@ class Validate
             if (isset($rule[2])) {
                 $imageType = strtolower($rule[2]);
 
-                if ('jpeg' == $imageType) {
-                    $imageType = 'jpg';
+                if ('jpg' == $imageType) {
+                    $imageType = 'jpeg';
                 }
 
                 if (image_type_to_extension($type, false) != $imageType) {


### PR DESCRIPTION
Validate.php文件1084行 image_type_to_extension($type, false)方法，当$type为2时，返回jpeg,
而前面代码又把jpeg改为jpg,造成jpg!=jpeg,使得验证结果返回false
应该反了