### PR TITLE
修复使用路由验证后路由变量丢失的问题

### DIFF
--- a/src/think/route/Dispatch.php
+++ b/src/think/route/Dispatch.php
@@ -139,16 +139,16 @@ abstract class Dispatch
             $this->createBindModel($option['model'], $this->param);
         }
 
-        // 数据自动验证
-        if (isset($option['validate'])) {
-            $this->autoValidate($option['validate']);
-        }
-
         // 记录当前请求的路由规则
         $this->request->setRule($this->rule);
 
         // 记录路由变量
         $this->request->setRoute($this->param);
+
+        // 数据自动验证
+        if (isset($option['validate'])) {
+            $this->autoValidate($option['validate']);
+        }
     }
 
     /**


### PR DESCRIPTION
修复 #2123 的问题。

数据验证的``$this->autoValidate()``方法中会调用到``$this->request->param()``。
```php
        /** @var Validate $v */
        $v->message($message)
            ->batch($batch)
            ->failException(true)
            ->check($this->request->param());
```
其中有对请求参数和URL地址中的参数合并的操作：
```php
$this->param = array_merge($this->param, $this->get(false), $vars, $this->route(false));
```
但此时还没有路由参数还没有设置。

因此需要先执行``$this->request->setRoute()``方法设置路由参数后，再进行验证操作。