### PR TITLE
[fixbug]session使用完后，由于默认配置判断跳过了 session_write_close()，导致session阻塞bug

### DIFF
--- a/library/think/Session.php
+++ b/library/think/Session.php
@@ -352,11 +352,11 @@ class Session
      */
     protected function unlock()
     {
+        $this->pause();
+
         if (empty($this->lock)) {
             return;
         }
-
-        $this->pause();
 
         if ($this->lockDriver && method_exists($this->lockDriver, 'unlock')) {
             $sessID = isset($_COOKIE[$this->sessKey]) ? $_COOKIE[$this->sessKey] : '';


### PR DESCRIPTION
session使用完后，由于默认配置判断跳过了 session_write_close()，导致session阻塞bug。
举例：
前端js code（三个请求ajax1、ajax2、ajax3同时进行）
```
<script src="https://cdn.bootcss.com/jquery/3.4.0/jquery.js"></script>
<script>
    var a = 1;
    var b = 1;
    var c = 1;
    function ajax1(){
        $.get('/hello?from=a', function(){
            console.log('a' , a);
            a++;
            ajax1();
        });
    }
    function ajax2(){
        $.get('/hello?from=b', function(){
            console.log('b',b);
            b++;
            ajax2();
        });
    }
    function ajax3(){
        $.get('/hello?from=c', function(){
            console.log('c',c);
            c++;
            ajax3();
        });
    }

    function beginAjax(){
        ajax1();
        ajax2();
        ajax3();
    }
    beginAjax();
</script>
```
TP5.1后端code
```
<?php
namespace app\index\controller;

use think\Controller;

class Index extends Controller
{
    public function index()
    {
        return $this->fetch();
    }

    public function hello($name = 'ThinkPHP5')
    {
        session('qanda','1'); //session是tp5.1的定义的方法
        sleep(5);
        return json(['data'=>session_id()]);
    }
}
```
Chrome浏览器
![](http://img.zzhpeng.cn/FvVEgokNtB95OjJRUcH21E2BCvCY)
