### PR TITLE
F: 修复 \think\File  -> hashName() 报错

### DIFF
--- a/src/think/File.php
+++ b/src/think/File.php
@@ -161,7 +161,7 @@ class File extends SplFileInfo
      * @param string|\Closure $rule
      * @return string
      */
-    public function hashName($rule = 'date'): string
+    public function hashName($rule = ''): string
     {
         if (!$this->hashName) {
             if ($rule instanceof \Closure) {

--- a/src/think/file/UploadedFile.php
+++ b/src/think/file/UploadedFile.php
@@ -8,7 +8,7 @@
 // +----------------------------------------------------------------------
 // | Author: yunwuxin <448901948@qq.com>
 // +----------------------------------------------------------------------
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace think\file;
 
@@ -60,13 +60,13 @@ class UploadedFile extends File
                 $error = $msg;
             });
 
-            $moved = move_uploaded_file($this->getPathname(), $target);
+            $moved = move_uploaded_file($this->getPathname(), (string) $target);
             restore_error_handler();
             if (!$moved) {
                 throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, strip_tags($error)));
             }
 
-            @chmod($target, 0666 & ~umask());
+            @chmod((string) $target, 0666 & ~umask());
 
             return $target;
         }


### PR DESCRIPTION
默认指为`date` 时达不到预期效果

```php
\is_callable('date')  // true
```
抛出异常

date() expects at least 1 parameter, 0 given
