### PR TITLE
5.0 Windows::write() 变量判断错误

### DIFF
--- a/library/think/cache/driver/Redis.php
+++ b/library/think/cache/driver/Redis.php
@@ -70,7 +70,7 @@ class Redis extends Driver
      */
     public function has($name)
     {
-        return $this->handler->exists($this->getCacheKey($name));
+        return (bool) $this->handler->exists($this->getCacheKey($name));
     }
 
     /**

--- a/library/think/process/pipes/Windows.php
+++ b/library/think/process/pipes/Windows.php
@@ -196,7 +196,7 @@ class Windows extends Pipes
             return;
         }
 
-        if (null !== $w && 0 < count($r)) {
+        if (null !== $r && 0 < count($r)) {
             $data = '';
             while ($dataread = fread($r['input'], self::CHUNK_SIZE)) {
                 $data .= $dataread;


### PR DESCRIPTION
php7.2+、Windows下会出现以下错误
```
count(): Parameter must be an array or an object that implements Countable
```
关联issue [#61](https://github.com/top-think/think-queue/issues/61)

5.1已[修复](https://github.com/top-think/framework/commit/c9b5134ac8bf2123fc9dc932e1d7b20c5d333d5d#diff-e94505412d60b41b93e10669cc45d186)