### PR TITLE
增加mysql json类型字段->>方式获取支持

### DIFF
--- a/library/think/db/builder/Mysql.php
+++ b/library/think/db/builder/Mysql.php
@@ -125,7 +125,13 @@ class Mysql extends Builder
 
         $key = trim($key);
 
-        if (strpos($key, '->') && false === strpos($key, '(')) {
+        if(strpos($key, '->>') && false === strpos($key, '(')){
+            // JSON字段支持
+            list($field, $name) = explode('->>', $key, 2);
+
+            return $this->parseKey($query, $field, true) . '->>\'$' . (strpos($name, '[') === 0 ? '' : '.') . str_replace('->>', '.', $name) . '\'';
+        }
+        elseif (strpos($key, '->') && false === strpos($key, '(')) {
             // JSON字段支持
             list($field, $name) = explode('->', $key, 2);
 


### PR DESCRIPTION
->>获取数据不带有双引号，避免了双引号所引起的查询不匹配问题