### PR TITLE
优化视图对模板的异常处理

### DIFF
--- a/src/think/View.php
+++ b/src/think/View.php
@@ -120,7 +120,12 @@ class View extends Manager
         // 渲染输出
         try {
             $callback();
+        }catch (\think\exception\HttpResponseException $e) {
+            throw $e;
         } catch (\Exception $e) {
+            ob_end_clean();
+            throw $e;
+        } catch (\Error $e) {
             ob_end_clean();
             throw $e;
         }


### PR DESCRIPTION
模板里用不了`halt()`，错误信息（类不存在）的显示也不大友好