### PR TITLE
修复5.1图片严格验证返回有误

### DIFF
--- a/library/think/File.php
+++ b/library/think/File.php
@@ -269,7 +269,7 @@ class File extends SplFileObject
         $extension = strtolower(pathinfo($this->getInfo('name'), PATHINFO_EXTENSION));
 
         /* 对图像文件进行严格检测 */
-        if (in_array($extension, ['gif', 'jpg', 'jpeg', 'bmp', 'png', 'swf']) && !in_array($this->getImageType($this->filename), [1, 2, 3, 4, 6, 13])) {
+        if (!in_array($extension, ['gif', 'jpg', 'jpeg', 'bmp', 'png', 'swf']) || !in_array($this->getImageType($this->filename), [1, 2, 3, 4, 6, 13])) {
             $this->error = 'illegal image files';
             return false;
         }


### PR DESCRIPTION
原先代码：

https://github.com/top-think/framework/blob/922161adade217be5b2094b70eeaf2ce388f6c35/library/think/File.php#L271-L278

这里 `if (in_array($extension, ['gif', 'jpg', 'jpeg', 'bmp', 'png', 'swf']) &&...`  的后缀名校验有问题啊，如果上传的文件名随便是 `xxx.exe` 的话，就绕过了。

应该是后缀名合法，且imagetype合法，才返回true。