### PR TITLE
修复使用路由到模版时路由变量丢失

### DIFF
--- a/src/think/route/Rule.php
+++ b/src/think/route/Rule.php
@@ -659,7 +659,7 @@ abstract class Rule
         } elseif ($route instanceof Response) {
             $result = new ResponseDispatch($request, $this, $route);
         } elseif (isset($option['view']) && false !== $option['view']) {
-            $result = new ViewDispatch($request, $this, $route, is_array($option['view']) ? $option['view'] : $this->vars);
+            $result = new ViewDispatch($request, $this, $route, array_merge($option['view'], $this->vars));
         } elseif (!empty($option['redirect'])) {
             // 路由到重定向地址
             $result = new RedirectDispatch($request, $this, $route, $this->vars, $option['status'] ?? 301);


### PR DESCRIPTION
在`src\think\route\Rule.php`的`dispatch`方法中有如下定义：
```php
$result = new ViewDispatch($request, $this, $route, is_array($option['view']) ? $option['view'] : $this->vars);
```
通过测试，`$option['view']`无论是否在路由定义中指定额外变量都为数组。
```
Route::view('index/:id', 'index/index', ['test' => 'value']);
var_dump($option['view']);
//array(1) { ["test"]=> string(5) "value" }

Route::view('index/:id', 'index/index');
var_dump($option['view']);
//array(0) { }
```
而路由变量存储于`$this->vars`，上述判断会导致任何情况下路由变量都会丢失，因此去除`is_array`判断，并执行`array_merge`操作合并两者。