### PR TITLE
添加特性：允许路由规则中使用类名以实现更复杂的调度逻辑

### DIFF
--- a/src/think/route/Rule.php
+++ b/src/think/route/Rule.php
@@ -653,6 +653,8 @@ abstract class Rule
     {
         if ($route instanceof Dispatch) {
             $result = $route;
+        } elseif (is_subclass_of($route, Dispatch::class)) {
+            $result = new $route($request, $this, $route, $this->vars);
         } elseif ($route instanceof Closure) {
             // 执行闭包
             $result = new CallbackDispatch($request, $this, $route, $this->vars);


### PR DESCRIPTION
添加新特性：
允许路由规则中使用类名以实现更复杂的调度逻辑

使用举例：
```php
<?php
// router.php
// 路由文件
Route::get('service', \app\HelloDispatch::class);
```

```php
<?php
// 自定义的Dispatch类
declare (strict_types = 1);

namespace app;

use think\route\Dispatch;

class HelloDispatch extends Dispatch
{
    public function exec()
    {
        return 'Hello world';
    }
}
```

此特性的使用场景：
需要将多个接口使用同一个接入点调用的情形（例如手动实现的RPC）。
附一张我们小组的奇葩接口规范：
![image](https://user-images.githubusercontent.com/7535112/75136431-aa3dc900-571f-11ea-9b7d-97a6c7990c5f.png)

对于以上需求，如果采用此特性来定制调度逻辑，会非常简单：
```php
<?php
// router.php
// 路由文件
Route::get('/api/v2/rpc', \app\ServiceDispatch::class);
```

```php
<?php
declare (strict_types = 1);

namespace app;

use think\App;
use think\route\dispatch\Controller as ControllerDispatch;

/**
 * Service Dispatcher
 */
class ServiceDispatch extends ControllerDispatch
{
    protected $actionKey = 'action';
    protected $defaultController = 'Index';
    protected $defaultAction = 'index';

    public function init(App $app)
    {
        $this->app = $app;

        // 执行路由后置操作
        $this->doRouteAfter();

        // 从请求输入种获取控制器名和操作名
        [$controller, $action] = $this->getControllerActionFromParam();

        $this->controller = $controller;
        $this->actionName = $action;
        
        // 设置当前请求的控制器、操作
        $this->request
            ->setController($this->controller)
            ->setAction($this->actionName);
    }

    /**
     * 从请求输入种获取控制器名和操作名
     */
    protected function getControllerActionFromParam()
    {
        $actionParam = $this->request->param($this->actionKey) ?? '';
        $list = empty($actionParam) ? [] : explode ('.', $actionParam);
        $n = count($list);

        $controller = $this->defaultController;
        $action = $this->defaultAction;
        if ($n >= 1) {
            $action = array_pop($list);
        }
        if ($n >= 2) {
            $controller = array_pop($list);
        }
    
        return [$controller, $action];
    }
}
```

以上方案已经在我们小组的项目中初步进行过测试没有问题，并且实际上由于可以自己改写调度逻辑，其实可扩展性会更强。

已经在本地测试运行过所有的测试样例，结果如下：
![image](https://user-images.githubusercontent.com/7535112/75136582-20423000-5720-11ea-8fbc-b1c2a182eed3.png)

请务必考虑下将此特性加入主分支，我们公司一直是ThinkPHP的忠实用户，也希望能对ThinkPHP做出一点微小的贡献。