### PR TITLE
Log config `time_format` support `u` for real microseconds.

### DIFF
--- a/src/think/log/driver/File.php
+++ b/src/think/log/driver/File.php
@@ -72,7 +72,7 @@ class File implements LogHandlerInterface
         $info = [];
 
         // 日志信息封装
-        $time = date($this->config['time_format']);
+        $time = \DateTime::createFromFormat('0.u00 U', microtime())->format($this->config['time_format']);
 
         foreach ($log as $type => $val) {
             $message = [];


### PR DESCRIPTION
Log config `time_format` support `u` for real microseconds rather than `000000`.

* Log config example:
```
'time_format'    => 'Y-m-d H:i:s.u',
```
* Logs:
```
[2020-03-22 16:09:54.606361][info] Hello ThinkPHP.
```