### PR TITLE
修正日志记录时区问题

### DIFF
--- a/src/think/log/driver/File.php
+++ b/src/think/log/driver/File.php
@@ -72,7 +72,7 @@ class File implements LogHandlerInterface
         $info = [];
 
         // 日志信息封装
-        $time = \DateTime::createFromFormat('0.u00 U', microtime())->format($this->config['time_format']);
+        $time = \DateTime::createFromFormat('0.u00 U', microtime())->setTimezone(new \DateTimeZone(date_default_timezone_get()))->format($this->config['time_format']);
 
         foreach ($log as $type => $val) {
             $message = [];


### PR DESCRIPTION
日志时间格式添加`u`微秒支持以后时区有问题，明确设置当前时区可以修正。