### PR TITLE
'修复自定义命令别名比系统别名长导致报错问题'

### DIFF
--- a/src/think/console/output/Descriptor.php
+++ b/src/think/console/output/Descriptor.php
@@ -216,7 +216,7 @@ class Descriptor
         $description        = new ConsoleDescription($console, $describedNamespace);
 
         if (isset($options['raw_text']) && $options['raw_text']) {
-            $width = $this->getColumnWidth($description->getCommands());
+            $width = $this->getColumnWidth($description->getNamespaces());
 
             foreach ($description->getCommands() as $command) {
                 $this->writeText(sprintf("%-${width}s %s", $command->getName(), $command->getDescription()), $options);
@@ -235,7 +235,7 @@ class Descriptor
             $this->writeText("\n");
             $this->writeText("\n");
 
-            $width = $this->getColumnWidth($description->getCommands());
+            $width = $this->getColumnWidth($description->getNamespaces());
 
             if ($describedNamespace) {
                 $this->writeText(sprintf('<comment>Available commands for the "%s" namespace:</comment>', $describedNamespace), $options);
@@ -282,14 +282,18 @@ class Descriptor
     }
 
     /**
-     * @param Command[] $commands
+     * @param Namespaces[] $namespaces
      * @return int
      */
-    private function getColumnWidth(array $commands)
+    private function getColumnWidth(array $namespaces)
     {
         $width = 0;
-        foreach ($commands as $command) {
-            $width = strlen($command->getName()) > $width ? strlen($command->getName()) : $width;
+        foreach ($namespaces as $namespace) {
+            foreach ($namespace['commands'] as $name) {
+                if (strlen($name) > $width) {
+                    $width = strlen($name);
+                }
+            }
         }
 
         return $width + 2;


### PR DESCRIPTION
修复自定义命令别名比系统别名长导致报错问题

当前tp6下 如果使用了命令行 名称比系统名称长时候 执行 php think list时候报错