### PR TITLE
修复 session使用 json_encode, json_decode序列化 返回数据格式错误

### DIFF
--- a/src/think/session/Store.php
+++ b/src/think/session/Store.php
@@ -333,7 +333,9 @@ class Store
     protected function unserialize(string $data): array
     {
         $unserialize = $this->serialize[1] ?? 'unserialize';
-
+        if ($unserialize === 'json_decode') {
+            return (array) $unserialize($data, true);
+        }
         return (array) $unserialize($data);
     }
 


### PR DESCRIPTION
修复 session使用 json_encode, json_decode序列化 返回数据格式错误
按照官方手册设置JSON序列化
'serialize'    =>    ['json_encode', 'json_decode']
session 返回的二维数组就变成了object类型 
Array
(
    [__token__] => a0607f0359856e9ffa8f2d0d90660701
    [captcha] => stdClass Object
        (
            [key] => $2y$10$aAYAxYWvqMUGZbNsazZouOfNZ73dbMi.rlHzqYv53McvE1XyM1t1q
        )

)