### PR TITLE
修复php7.4下不推荐花括号访问数组

### DIFF
--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -397,7 +397,7 @@ class Query
                         $seq = (ord(substr($type($value), 0, 1)) % $rule['num']) + 1;
                     } else {
                         // 按照字段的首字母的值分表
-                        $seq = (ord($value{0}) % $rule['num']) + 1;
+                        $seq = (ord($value[0]) % $rule['num']) + 1;
                     }
             }
             return $this->getTable() . '_' . $seq;


### PR DESCRIPTION
修复php7.4下不推荐花括号访问数组： Array and string offset access syntax with curly braces is deprecated