### PR TITLE
增加预检缓存 有效期1800秒

### DIFF
--- a/src/think/middleware/AllowCrossDomain.php
+++ b/src/think/middleware/AllowCrossDomain.php
@@ -26,6 +26,7 @@ class AllowCrossDomain
 
     protected $header = [
         'Access-Control-Allow-Credentials' => 'true',
+        'Access-Control-Max-Age'           => 1800,
         'Access-Control-Allow-Methods'     => 'GET, POST, PATCH, PUT, DELETE, OPTIONS',
         'Access-Control-Allow-Headers'     => 'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, X-CSRF-TOKEN, X-Requested-With',
     ];


### PR DESCRIPTION
增加预检缓存 有效期1800秒
30分钟内同一条url再次请求，不再发送预检，也就是说30分钟内再次请求不会出现 options预检请求