### PR TITLE
异常页面显示数据库错误扩展信息

### DIFF
--- a/src/think/exception/Handle.php
+++ b/src/think/exception/Handle.php
@@ -302,17 +302,20 @@ class Handle
 
     /**
      * 获取异常扩展信息
-     * 用于非调试模式html返回类型显示
+     * 用于调试模式html返回类型显示
      * @access protected
      * @param Throwable $exception
      * @return array                 异常类定义的扩展数据
      */
     protected function getExtendData(Throwable $exception): array
     {
-        $data = [];
-
-        if ($exception instanceof \think\Exception) {
+        if (
+            $exception instanceof \think\Exception
+            || (class_exists('\think\db\exception\DbException') && $exception instanceof \think\db\exception\DbException)
+        ) {
             $data = $exception->getData();
+        } else {
+            $data = [];
         }
 
         return $data;


### PR DESCRIPTION
现在SQL语句发生错误时，只显示错误信息，但没有显示错误的SQL语句，不方便开发时调试