### PR TITLE
解决由于架构设计原因，app_debug和config_ext的配置只能在环境变量中修改 的问题，经过这次修改后可在入口文件动态声明 AP…

### DIFF
--- a/src/think/App.php
+++ b/src/think/App.php
@@ -532,7 +532,11 @@ class App extends Container
     {
         // 应用调试模式
         if (!$this->appDebug) {
-            $this->appDebug = $this->env->get('app_debug') ? true : false;
+            if(defined('APP_DEBUG')){
+                $this->appDebug = APP_DEBUG;
+            }else{
+                $this->appDebug = $this->env->get('app_debug') ? true : false;
+            }
             ini_set('display_errors', 'Off');
         }
 


### PR DESCRIPTION
app_debug和config_ext的配置只能在环境变量中修改我感觉这样不好，这样是比以前的版本退步了，不灵活。比如我有这样的需求：我有个小项目或个人网站需要在线上debug一个测试环境不容易重现的BUG，但最好同时就不要影响在线用户，如果确定不小心影响了也不是很大的问题因为这是小项目或个人网站。 所以我需要根据访客IP决定是否开启app_debug，这样我就可以在入口文件判断出如果是我的IP就声明APP_DEBUG为true，这样我访问时就会开启debug模式。
我这样的修改或许不优雅或许不适合整合到TP通用版的框架，但是建议官方最好是解决app_debug和config_ext的配置只能在环境变量中修改的问题，我感觉如果是官方来改一下这个问题应该不难改。还有就是现在APP_TRACE好像也没有单独配置开启或关闭了，最好是也改进一下。