### PR TITLE
解决关联预加载逗号分隔符中出现空格导致无法解析的问题

### DIFF
--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -2591,8 +2591,12 @@ class Query
                 $relation = $key;
             } elseif (is_array($relation)) {
                 $relation = $key;
-            } elseif (is_string($relation) && strpos($relation, '.')) {
-                list($relation, $subRelation) = explode('.', $relation, 2);
+            } elseif (is_string($relation)) {
+            	// 去处首尾空格
+            	$relation = trim($relation);
+				if (strpos($relation, '.')) {
+					list($relation, $subRelation) = explode('.', $relation, 2);
+				}
             }
 
             /** @var Relation $model */
@@ -2647,8 +2651,12 @@ class Query
             } elseif (is_array($relation)) {
                 $field    = $relation;
                 $relation = $key;
-            } elseif (is_string($relation) && strpos($relation, '.')) {
-                list($relation, $subRelation) = explode('.', $relation, 2);
+            } elseif (is_string($relation)) {
+            	// 去处首尾空格
+            	$relation = trim($relation);
+				if (strpos($relation, '.')) {
+					list($relation, $subRelation) = explode('.', $relation, 2);
+				}
             }
 
             /** @var Relation $model */

--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -2592,11 +2592,11 @@ class Query
             } elseif (is_array($relation)) {
                 $relation = $key;
             } elseif (is_string($relation)) {
-            	// 去处首尾空格
-            	$relation = trim($relation);
-				if (strpos($relation, '.')) {
-					list($relation, $subRelation) = explode('.', $relation, 2);
-				}
+                // 去处首尾空格
+                $relation = trim($relation);
+                if (strpos($relation, '.')) {
+                    list($relation, $subRelation) = explode('.', $relation, 2);
+                }
             }
 
             /** @var Relation $model */
@@ -2652,11 +2652,11 @@ class Query
                 $field    = $relation;
                 $relation = $key;
             } elseif (is_string($relation)) {
-            	// 去处首尾空格
-            	$relation = trim($relation);
-				if (strpos($relation, '.')) {
-					list($relation, $subRelation) = explode('.', $relation, 2);
-				}
+                // 去处首尾空格
+                $relation = trim($relation);
+                if (strpos($relation, '.')) {
+                    list($relation, $subRelation) = explode('.', $relation, 2);
+                }
             }
 
             /** @var Relation $model */


### PR DESCRIPTION
with方法传入字符串使用逗号进行分隔时，如果有空格，会导致无法找到对应的方法。
```php
User::with('profile, book')->select();
```