### PR TITLE
修复偶发反序列化时的报错

### DIFF
--- a/src/think/cache/driver/File.php
+++ b/src/think/cache/driver/File.php
@@ -136,7 +136,7 @@ class File extends Driver
 
         $raw = $this->getRaw($name);
 
-        return is_null($raw) ? $default : $this->unserialize($raw['content']);
+        return is_null($raw) || !is_string($raw['content']) ? $default : $this->unserialize($raw['content']);
     }
 
     /**


### PR DESCRIPTION
解决助手函数download访问文件时偶发（可能是高并发，或带宽不足）情况下，的报错

[0]Argument 1 passed to think\cache\Driver::unserialize() must be of the type string, boolean given, called in /www/wwwroot/xxxxxxxxx/vendor/topthink/framework/src/think/cache/driver/File.php on line 139