### PR TITLE
增加文件缓存自定后缀参数

### DIFF
--- a/src/think/cache/driver/File.php
+++ b/src/think/cache/driver/File.php
@@ -26,6 +26,7 @@ class File extends Driver
      * @var array
      */
     protected $options = [
+        'ext'           =>'.php',
         'expire'        => 0,
         'cache_subdir'  => true,
         'prefix'        => '',
@@ -45,6 +46,10 @@ class File extends Driver
     {
         if (!empty($options)) {
             $this->options = array_merge($this->options, $options);
+        }
+        
+        if (empty($this->options['ext'])){
+            $this->options['ext'] = '.php';
         }
 
         if (empty($this->options['path'])) {
@@ -75,7 +80,7 @@ class File extends Driver
             $name = $this->options['prefix'] . DIRECTORY_SEPARATOR . $name;
         }
 
-        return $this->options['path'] . $name . '.php';
+        return $this->options['path'] . $name . $this->options['ext'];
     }
 
     /**


### PR DESCRIPTION
文件缓存开启opcache时读取出错，这里允许自定后缀防止会缓存