### PR TITLE
Update Redis.php

### DIFF
--- a/src/think/cache/driver/Redis.php
+++ b/src/think/cache/driver/Redis.php
@@ -87,7 +87,7 @@ class Redis extends Driver
         }
 
         if (0 != $this->options['select']) {
-            $this->handler->select($this->options['select']);
+            $this->handler->select( (int) $this->options['select']);
         }
     }
 


### PR DESCRIPTION
select 为字符串时,会报错,且在APP_DEBUG=true和show_error_msg=true的情况下也不能正常显示错误信息,也不能正常记录错误日志