### PR TITLE
fix: 解决某些情况下 Response/File ob_end_clean 执行错误

### DIFF
--- a/src/think/response/File.php
+++ b/src/think/response/File.php
@@ -44,7 +44,7 @@ class File extends Response
             throw new Exception('file not exists:' . $data);
         }
 
-        ob_end_clean();
+        @ob_end_clean();
 
         if (!empty($this->name)) {
             $name = $this->name;


### PR DESCRIPTION
ob_end_clean() failed to delete buffer. no buffer to delete