### PR TITLE
SoftDelete删除条件做空判断

### DIFF
--- a/library/think/model/concern/SoftDelete.php
+++ b/library/think/model/concern/SoftDelete.php
@@ -139,6 +139,10 @@ trait SoftDelete
      */
     public static function destroy($data, $force = false)
     {
+        // 传入空不执行删除，但是0可以删除
+        if (empty($data) && 0 !== $data) {
+            return false;
+        }
         // 包含软删除数据
         $query = (new static())->db(false);
 


### PR DESCRIPTION
每次使用destory进行软删除的时候，如果传入空数组，则会造成删除所有数据。