### PR TITLE
修复POST数据大时触发CURL 100-continue，导致CURL请求时间加长

### DIFF
--- a/library/think/log/driver/Socket.php
+++ b/library/think/log/driver/Socket.php
@@ -269,6 +269,7 @@ class Socket
 
         $headers = [
             "Content-Type: application/json;charset=UTF-8",
+            'Expect:',
         ];
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers); //设置header


### PR DESCRIPTION
修复POST数据大时触发CURL 100-continue，导致CURL请求时间加长