### PR TITLE
fix implode(), swap the parameters

### DIFF
--- a/library/think/db/Builder.php
+++ b/library/think/db/Builder.php
@@ -386,7 +386,7 @@ abstract class Builder
                     $array[] = $key . ' ' . $exp . ' ' . $this->parseValue($item, $field);
                 }
                 $logic = isset($val[2]) ? $val[2] : 'AND';
-                $whereStr .= '(' . implode($array, ' ' . strtoupper($logic) . ' ') . ')';
+                $whereStr .= '(' . implode(' ' . strtoupper($logic) . ' ', $array) . ')';
             } else {
                 $whereStr .= $key . ' ' . $exp . ' ' . $this->parseValue($value, $field);
             }


### PR DESCRIPTION
fix implode(): Passing glue string after array is deprecated. Swap the parameters