### PR TITLE
导出`SocketLog` 的`curl`超时设置

### DIFF
--- a/src/think/log/driver/Socket.php
+++ b/src/think/log/driver/Socket.php
@@ -41,6 +41,11 @@ class Socket implements LogHandlerInterface
         'expand_level'        => ['debug'],
         // 日志头渲染回调
         'format_head'         => null,
+        // curl opt
+        'curl_opt'            => [
+            CURLOPT_CONNECTTIMEOUT => 1,
+            CURLOPT_TIMEOUT        => 10,
+        ],
     ];
 
     protected $css = [
@@ -292,8 +297,8 @@ class Socket implements LogHandlerInterface
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $message);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->config['curl_opt'][CURLOPT_CONNECTTIMEOUT] ?? 1);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $this->config['curl_opt'][CURLOPT_TIMEOUT] ?? 10);
 
         $headers = [
             "Content-Type: application/json;charset=UTF-8",


### PR DESCRIPTION
导出`log-socket`驱动超时设置选项，以适配外网调试时网络波动延迟导致无法收到日志的问题。