### PR TITLE
改进响应文件请求时的缓冲清除

### DIFF
--- a/src/think/response/File.php
+++ b/src/think/response/File.php
@@ -44,7 +44,9 @@ class File extends Response
             throw new Exception('file not exists:' . $data);
         }
 
-        ob_end_clean();
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
 
         if (!empty($this->name)) {
             $name = $this->name;


### PR DESCRIPTION
解决某些情况下响应文件请求时执行`ob_end_clean `时发生`ob_end_clean() failed to delete buffer. no buffer to delete`错误

close #2365

