### PR TITLE
修复未捕获异常无法保存在日志中

### DIFF
--- a/src/think/initializer/Error.php
+++ b/src/think/initializer/Error.php
@@ -56,6 +56,7 @@ class Error
             $handler->renderForConsole(new ConsoleOutput, $e);
         } else {
             $handler->render($this->app->request, $e)->send();
+            $this->app->log->save();
         }
     }
 


### PR DESCRIPTION
在执行$http-run()阶段里的初始化方法时，$this->initialize()该方法未在catch块中，根据不想暴露具体错误到服务端的原则，所以需要将日志记录到日志文件中，但实际未记录