### PR TITLE
$request->ip() 方法兼容PHP8

### DIFF
--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -1659,7 +1659,7 @@ class Request implements ArrayAccess
                 $flag = FILTER_FLAG_IPV6;
                 break;
             default:
-                $flag = null;
+                $flag = 0;
                 break;
         }
 


### PR DESCRIPTION
PHP 8 当前方法错误提示
filter_var(): Argument #3 ($options) must be of type array|int, null given