### PR TITLE
controller 方法增加获取多层控制器最后控制器名称

### DIFF
--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -1854,12 +1854,16 @@ class Request implements ArrayAccess
     /**
      * 获取当前的控制器名
      * @access public
-     * @param  bool $convert 转换为小写
+     * @param bool $convert 转换为小写
+     * @param bool $suffix  获取多层控制器最后控制器名称
      * @return string
      */
-    public function controller(bool $convert = false): string
+    public function controller (bool $convert = false, bool $suffix = false): string
     {
         $name = $this->controller ?: '';
+        if ($suffix and $suffix_offset = strpos($name, '.')) {
+            $name = substr($name, $suffix_offset + 1);
+        }
         return $convert ? strtolower($name) : $name;
     }
 


### PR DESCRIPTION
使用方法 Request::controller(false, true); 第二参数设置为true；
PHP8可以直接 Reuqest::controller(suffix:true);
主要效果
v1.main 使用新方法后可以直接获取 mian控制器名称