### PR TITLE
正确的返回,用抛exception的方式不太合理

### DIFF
--- a/library/traits/controller/Jump.php
+++ b/library/traits/controller/Jump.php
@@ -60,7 +60,7 @@ trait Jump
 
         $response = Response::create($result, $type)->header($header)->options(['jump_template' => $this->app['config']->get('dispatch_success_tmpl')]);
 
-        throw new HttpResponseException($response);
+        $response->send();
     }
 
     /**


### PR DESCRIPTION
正确的返回,用抛exception的方式不太合理,可以直接调用send()方法返回,请参考