### PR TITLE
修复debug模式下编码问题导致的json_encode失效问题'

### DIFF
--- a/src/think/exception/Handle.php
+++ b/src/think/exception/Handle.php
@@ -340,7 +340,7 @@ class Handle
     protected function changeToUtf8(array $data): array
     {
         foreach ($data as $key => $value) {
-            $data[$key] =  mb_convert_encoding($value, "UTF-8","GBK, GBK2312");
+            $data[$key] =  mb_convert_encoding($value, "UTF-8", "GBK, GBK2312");
         }
 
         return $data;

--- a/src/think/exception/Handle.php
+++ b/src/think/exception/Handle.php
@@ -176,7 +176,7 @@ class Handle
                     'Files'               => $this->app->request->file(),
                     'Cookies'             => $this->app->request->cookie(),
                     'Session'             => $this->app->exists('session') ? $this->app->session->all() : [],
-                    'Server/Request Data' => $this->app->request->server(),
+                    'Server/Request Data' => $this->changeToUtf8($this->app->request->server()),
                 ],
             ];
         } else {
@@ -328,5 +328,21 @@ class Handle
         $const = get_defined_constants(true);
 
         return $const['user'] ?? [];
+    }
+    
+    /**
+     * 将获取的服务器信息中的中文编码转为utf-8
+     * 修复在开启debug模式时出现的Malformed UTF-8 characters 错误
+     * @access protected
+     * @param $data array
+     * @return array                 转化后的数组
+     */
+    protected function changeToUtf8(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            $data[$key] =  mb_convert_encoding($value, "UTF-8","GBK, GBK2312");
+        }
+
+        return $data;
     }
 }


### PR DESCRIPTION
如果计算机名为中文（本地开发常见）。在debug开启的模式下，会因为编码问题导致json_decode()失效，而报‘’Malformed UTF-8 characters‘’的错误，会看不到具体的报错信息。