### PR TITLE
更新 think-installer 依赖版本

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "topthink/think-installer": "~1.0"
+        "topthink/think-installer": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",


### PR DESCRIPTION
更新 think-installer 依赖版本以修复 think-installer 1.x 在 macOS 下不支持 composer2 的问题。