### PR TITLE
cross-domain-bug

### DIFF
--- a/src/think/middleware/AllowCrossDomain.php
+++ b/src/think/middleware/AllowCrossDomain.php
@@ -51,7 +51,7 @@ class AllowCrossDomain
         if (!isset($header['Access-Control-Allow-Origin'])) {
             $origin = $request->header('origin');
 
-            if ($origin && ('' == $this->cookieDomain || strpos($origin, $this->cookieDomain))) {
+            if ($origin && ('' == $this->cookieDomain || strpos($this->cookieDomain, $origin) !== false)) {
                 $header['Access-Control-Allow-Origin'] = $origin;
             } else {
                 $header['Access-Control-Allow-Origin'] = '*';


### PR DESCRIPTION
设置cookie域名之后，跨域判断有误，导致跨域失败