### PR TITLE
子域名匹配 rtrim 参数类型错误

### DIFF
--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -408,7 +408,8 @@ class Request implements ArrayAccess
             $rootDomain = $this->rootDomain();
 
             if ($rootDomain) {
-                $this->subDomain = rtrim(stristr($this->host(), $rootDomain, true), '.');
+                $sub             = stristr($this->host(), $rootDomain, true);
+                $this->subDomain = $sub ? rtrim($sub, '.') : '';
             } else {
                 $this->subDomain = '';
             }


### PR DESCRIPTION
如果绑定根域名后 有其他域名访问会爆错 stristr 返回false rtrim 不支持bool参数