### PR TITLE
preflight request（预检测）处理

### DIFF
--- a/src/think/middleware/AllowCrossDomain.php
+++ b/src/think/middleware/AllowCrossDomain.php
@@ -60,7 +60,7 @@ class AllowCrossDomain
 
         $method = $_SERVER["REQUEST_METHOD"];
         if ($method == "OPTIONS"){
-            return Response('',200,$header);
+            return Response('', 200, $header);
         }
 
         return $next($request)->header($header);

--- a/src/think/middleware/AllowCrossDomain.php
+++ b/src/think/middleware/AllowCrossDomain.php
@@ -58,6 +58,11 @@ class AllowCrossDomain
             }
         }
 
+        $method = $_SERVER["REQUEST_METHOD"];
+        if ($method == "OPTIONS"){
+            return Response('',200,$header);
+        }
+
         return $next($request)->header($header);
     }
 }

--- a/src/think/middleware/AllowCrossDomain.php
+++ b/src/think/middleware/AllowCrossDomain.php
@@ -58,8 +58,7 @@ class AllowCrossDomain
             }
         }
 
-        $method = $_SERVER["REQUEST_METHOD"];
-        if ($method == "OPTIONS"){
+        if ($request->isOptions()){
             return Response('', 200, $header);
         }
 


### PR DESCRIPTION
preflight request（预检测）处理.如果是preflight request(预检请求),则直接返回预检测数据.这样能防止中间件继续处理.如果多个中间件,比如跨域检查中间件之后,还有权限验证就会报错.也避免了不必要的过多执行中间件.