### PR TITLE
多语言的配置参数初始化

### DIFF
--- a/library/think/App.php
+++ b/library/think/App.php
@@ -454,6 +454,10 @@ class App extends Container
 
     protected function loadLangPack()
     {
+        // 设置语言配置
+        $this->lang->setLangCookieVar($this->config('app.lang_cookie_var'));
+        $this->lang->setAllowLangList($this->config('app.allow_lang_list'));
+
         // 读取默认语言
         $this->lang->range($this->config('app.default_lang'));
 


### PR DESCRIPTION
多语言配置的两个参数 cookie_var 和 allow_lang_list 没有在语言包初始化时读取到
导致在第一次检测语言(detect)时没有按预期的效果实现