### PR TITLE
fix: 处理in校验"0"与"00"结果错误的问题

### DIFF
--- a/src/think/Validate.php
+++ b/src/think/Validate.php
@@ -1274,7 +1274,7 @@ class Validate
      */
     public function in($value, $rule): bool
     {
-        return in_array($value, is_array($rule) ? $rule : explode(',', $rule));
+        return in_array($value, is_array($rule) ? $rule : explode(',', $rule), true);
     }
 
     /**


### PR DESCRIPTION
在以下结果应该返回 false ,但是结果返回 true
```
    $data = [
        "name" =>  "0",
    ];
    $rule = [
        'name'  =>  "in:000",
    ];
    $checkMode = new Validate();
    $result = $checkMode->rule($rule)->check($data);
```