### PR TITLE
FIX 内置服务器启动默认host显示问题

### DIFF
--- a/src/think/console/command/RunServer.php
+++ b/src/think/console/command/RunServer.php
@@ -63,7 +63,7 @@ class RunServer extends Command
             escapeshellarg($root . DIRECTORY_SEPARATOR . 'router.php')
         );
 
-        $output->writeln(sprintf('ThinkPHP Development server is started On <http://%s:%s/>', '0.0.0.0' == $host ? '127.0.0.1' : $host, $port));
+        $output->writeln(sprintf('ThinkPHP Development server is started On <http://%s:%s/>', $host, $port));
         $output->writeln(sprintf('You can exit with <info>`CTRL-C`</info>'));
         $output->writeln(sprintf('Document root is: %s', $root));
         passthru($command);


### PR DESCRIPTION
通过php think run启动内置服务器默认是绑定在0.0.0.0:8000端口上的 但是显示的文案信息却是错误的

![image](https://user-images.githubusercontent.com/9588681/123251686-057df800-d4db-11eb-8472-3431ad4f5fdd.png)
