### PR TITLE
绑定路由参数，如果请求的参数为索引数组，路由参数取值不是url地址参数，而是body参数

### DIFF
--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -858,8 +858,7 @@ class Request implements ArrayAccess
             }
 
             // 当前请求参数和URL地址中的参数合并
-            $this->param = array_merge($this->param, $this->get(false), $vars, $this->route(false));
-
+            $this->param = array_merge($this->param, $this->route(false), $this->get(false), $vars);
             $this->mergeParam = true;
         }
 


### PR DESCRIPTION
例如：
- route 绑定参数： `http://capi.train.tinywan.cn/h/v1/user/{{uid}}/info-save`  请求地址： `http://capi.train.tinywan.cn/h/v1/user/10478916/info-save`
- post param

```
{
    "10086": "Tinywan",
    "10000": "mobile"
}
```

定义方法
```
    /**
     * @param int $uid
     * @return Response
     */
    public function infoSave(int $uid): Response{}
```
最后的参数是：
```
array(3) {
    [
        0
    ]=>
  string(7) "Tinywan"
  [
        1
    ]=>
  string(6) "mobile"
  [
        "uid"
    ]=>
  string(8) "10478916"
}
```
最后传入的参数 `infoSave(Tinywan)`

错误信息
```
Argument 1 passed to app\\controller\\home\\v1\\User::infoSave() must be of the type int, string given
```