### PR TITLE
Update File.php

### DIFF
--- a/src/think/log/driver/File.php
+++ b/src/think/log/driver/File.php
@@ -139,7 +139,9 @@ class File implements LogHandlerInterface
 
             try {
                 if (count($files) > $this->config['max_files']) {
+                    set_error_handler(function ($errno, $errstr, $errfile, $errline) {});
                     unlink($files[0]);
+                    restore_error_handler();
                 }
             } catch (\Exception $e) {
                 //


### PR DESCRIPTION
suppress errors here as unlink() might fail if two processes are cleaning up/rotating at the same time