### PR TITLE
修复复杂验证条件无效问题

### DIFF
--- a/src/think/Validate.php
+++ b/src/think/Validate.php
@@ -1145,6 +1145,18 @@ class Validate
                     $map[] = [$key, '=', $data[$key]];
                 }
             }
+        } elseif (strpos($key, '=')) {
+            // 支持复杂验证条件
+            $fields = explode('&', $key);
+            $map_arr=[];
+            foreach ($fields as $key) {
+                $str_map=explode('=',$key);
+                $map[] = [$str_map[0], '=',$str_map[1]];
+                $map_arr[]=$str_map[0];
+            }
+            if(!in_array($field,$map_arr)){
+                $map[]=[$field,'=',$data[$field]];
+            }
         } elseif (isset($data[$field])) {
             $map[] = [$key, '=', $data[$field]];
         } else {


### PR DESCRIPTION
```
// 复杂验证条件
'name'   => 'unique:user,status=1&account='.$data['account']
```
按照官方文档使用没有达到预期效果，会报错`not support data:status=1`，此pr修复该问题。

