### PR TITLE
fix: Container getObjectParam

### DIFF
--- a/src/think/Container.php
+++ b/src/think/Container.php
@@ -445,7 +445,7 @@ class Container implements ContainerInterface, ArrayAccess, IteratorAggregate, C
             $reflectionType = $param->getType();
 
             if ($reflectionType && $reflectionType->isBuiltin() === false) {
-                $args[] = $this->getObjectParam($reflectionType->getName(), $vars);
+                $args[] = $this->getObjectParam($param, $vars);
             } elseif (1 == $type && !empty($vars)) {
                 $args[] = array_shift($vars);
             } elseif (0 == $type && array_key_exists($name, $vars)) {
@@ -481,18 +481,21 @@ class Container implements ContainerInterface, ArrayAccess, IteratorAggregate, C
     /**
      * 获取对象类型的参数值
      * @access protected
-     * @param string $className 类名
+     * @param string $param     非内置对象类型的参数反射
      * @param array  $vars      参数
      * @return mixed
      */
-    protected function getObjectParam(string $className, array &$vars)
+    protected function getObjectParam(\ReflectionParameter $param, array &$vars)
     {
         $array = $vars;
         $value = array_shift($array);
+        $className = $param->getType()->getName();
 
         if ($value instanceof $className) {
             $result = $value;
             array_shift($vars);
+        } elseif ($param->isDefaultValueAvailable()) {
+            $result = $param->getDefaultValue();
         } else {
             $result = $this->make($className);
         }


### PR DESCRIPTION
getObjectParam 获取参数值时，优先使用声明的默认值，而不是实例化一个对象，因为某些类型约束声明可能是abstract
如：Pivot模型