### PR TITLE
增加多应用空控制器统一配置支持

### DIFF
--- a/src/think/route/dispatch/Controller.php
+++ b/src/think/route/dispatch/Controller.php
@@ -174,7 +174,7 @@ class Controller extends Dispatch
 
         if (class_exists($class)) {
             return $this->app->make($class, [], true);
-        } elseif ($emptyController && class_exists($emptyClass = $this->app->parseClass($controllerLayer, $emptyController . $suffix))) {
+        } else if ($emptyController && (class_exists($emptyClass = $this->app->parseClass($controllerLayer, $emptyController . $suffix)) or (strpos($emptyController, 'app') !== false and class_exists($emptyClass = $emptyController)))) {
             return $this->app->make($emptyClass, [], true);
         }
 


### PR DESCRIPTION
多应用空控制器统一配置后不再需要在每个应用下面添加Error空控制器文件
只要在config/route.php配置参数empty_controller到指定的空控制器路径就好
例如可以统一放置在app下面，只要配置
'empty_controller'      => "app\Error"
也可以放置在app\common下面
'empty_controller'      => "app\common\Error"

注意：必须放置在应用目录下面；