### PR TITLE
支持去除多层控制器默认前缀

### DIFF
--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -1875,11 +1875,15 @@ class Request implements ArrayAccess
      * 获取当前的控制器名
      * @access public
      * @param  bool $convert 转换为小写
+     * @param  bool $prefix 去除多层控制器前缀
      * @return string
      */
-    public function controller(bool $convert = false): string
+    public function controller(bool $convert = false, bool $prefix = false): string
     {
         $name = $this->controller ?: '';
+        if ($prefix and strpos($name, '.')) {
+            $name = substr($name, strripos($name, '.') + 1);
+        }
         return $convert ? strtolower($name) : $name;
     }
 


### PR DESCRIPTION
多层控制器通过controller获取的时候会出现
name.controller
这种问题，利用多层控制器做api版本切换的时候权限表记录的都是 应用名+控制器名+方法名（api::common::sendSms）
实际获取的话会出现 api::v1.common::sendSms
每次切换api版本的时候 都要批量修改权限表路由字段 更换v1为v2
为了更方便的使用 在特定场景直接 获取到api::common::sendSms来匹配用户是否有权限 不受版本号影响


用法：
PHP<8
$request->controller(true,true);
PHP>=8
$request->controller(prefix:true);
第一个true是将控制器转换为小写
第二个true是去除前缀