### PR TITLE
发送cookie前先检查header是否已发送

### DIFF
--- a/src/think/Response.php
+++ b/src/think/Response.php
@@ -130,16 +130,19 @@ abstract class Response
         // 处理输出数据
         $data = $this->getContent();
 
-        if (!headers_sent() && !empty($this->header)) {
-            // 发送状态码
-            http_response_code($this->code);
-            // 发送头部信息
-            foreach ($this->header as $name => $val) {
-                header($name . (!is_null($val) ? ':' . $val : ''));
+        if (!headers_sent()) {
+            if (!empty($this->header)) {
+                // 发送状态码
+                http_response_code($this->code);
+                // 发送头部信息
+                foreach ($this->header as $name => $val) {
+                    header($name . (!is_null($val) ? ':' . $val : ''));
+                }
             }
-        }
-        if ($this->cookie) {
-            $this->cookie->save();
+
+            if ($this->cookie) {
+                $this->cookie->save();
+            }
         }
 
         $this->sendData($data);


### PR DESCRIPTION
作用：发送cookie前先检查响应头header是否已发送

原因：在tp6.0框架中，调用easywechat或symfony等，并在这些包中已经响应了内容给浏览器，如果在tp打开了Session初始化中间件，会导致tp框架主动向浏览器发送PHPSESSION_ID的cookie，并在日志中报header已发送的错误。

场景：
一个项目中，有一部分接口需要用到session，所以需要打开tp6的session初始化。
而另外一些接口不需要用session（如微信开发的被动消息服务端，直接在easywechat包内响应内容），但由于项目的其他接口要用到session，所以项目是打开session初始化中间件的，当调用不需要用session的接口时，就会一直报header已发送的错误。