### PR TITLE
增加字符型和标量验证规则

### DIFF
--- a/src/lang/zh-cn.php
+++ b/src/lang/zh-cn.php
@@ -94,7 +94,8 @@ return [
 
     'The middleware must return Response instance'              => '中间件方法必须返回Response对象实例',
     'The queue was exhausted, with no response returned'        => '中间件队列为空',
-    // Validate Error Message
+
+    // 验证错误信息
     ':attribute require'                                        => ':attribute不能为空',
     ':attribute must'                                           => ':attribute必须',
     ':attribute must be numeric'                                => ':attribute必须是数字',
@@ -104,6 +105,8 @@ return [
     ':attribute not a valid email address'                      => ':attribute格式不符',
     ':attribute not a valid mobile'                             => ':attribute格式不符',
     ':attribute must be a array'                                => ':attribute必须是数组',
+    ':attribute must be a string'                               => ':attribute必须是字符型',
+    ':attribute must be a scalar'                               => ':attribute必须是标量',
     ':attribute must be yes,on or 1'                            => ':attribute必须是yes、on或者1',
     ':attribute not a valid datetime'                           => ':attribute不是一个有效的日期或时间格式',
     ':attribute not a valid file'                               => ':attribute不是有效的上传文件',

--- a/src/think/Validate.php
+++ b/src/think/Validate.php
@@ -69,6 +69,8 @@ class Validate
         'email'       => ':attribute not a valid email address',
         'mobile'      => ':attribute not a valid mobile',
         'array'       => ':attribute must be a array',
+        'string'      => ':attribute must be string',
+        'scalar'      => ':attribute must be scalar',
         'accepted'    => ':attribute must be yes,on or 1',
         'date'        => ':attribute not a valid datetime',
         'file'        => ':attribute not a valid file',
@@ -857,6 +859,14 @@ class Validate
             case 'array':
                 // 是否为数组
                 $result = is_array($value);
+                break;
+            case 'string':
+                // 是否为字符型
+                $result = is_string($value);
+                break;
+            case 'scalar':
+                // 是否为标量
+                $result = is_scalar($value);
                 break;
             case 'file':
                 $result = $value instanceof File;

--- a/src/think/Validate.php
+++ b/src/think/Validate.php
@@ -1126,7 +1126,7 @@ class Validate
      * 验证是否唯一
      * @access public
      * @param mixed  $value 字段值
-     * @param mixed  $rule  验证规则 格式：数据表,字段名,排除ID,主键名
+     * @param mixed  $rule  验证规则 格式：数据表,字段名,排除ID,主键名,软删除
      * @param array  $data  数据
      * @param string $field 验证字段名
      * @return bool
@@ -1157,8 +1157,6 @@ class Validate
             }
         } elseif (isset($data[$field])) {
             $map[] = [$key, '=', $data[$field]];
-        } else {
-            $map = [];
         }
 
         $pk = !empty($rule[3]) ? $rule[3] : $db->getPk();
@@ -1168,6 +1166,17 @@ class Validate
                 $map[] = [$pk, '<>', $rule[2]];
             } elseif (isset($data[$pk])) {
                 $map[] = [$pk, '<>', $data[$pk]];
+            }
+        }
+
+        // 软删除数据条件
+        if (isset($rule[4]) && false != $rule[4]) {
+            if (is_array($rule[4])) {
+                // 数组则直接设置为查询条件
+                $map[] = $rule[4];
+            } else {
+                // 其它则按照默认规则设置软删除条件
+                $map[] = ['delete_time', 'null', null];
             }
         }
 


### PR DESCRIPTION
随着越来越多系统函数严格输入参数类型，并且外部输入变量不可控，内置的部分验证方法已经不能满足验证的需求。
例如`date`验证规则，使用了`strtotime()`方法来验证输入值是否符合日期规范，但`strtotime()`的第一个参数要求是`string`类型。
现在使用验证器只能先处理一遍输入值，否则就会报输入类型错误，失去了便利性，故增加相关类型验证方法，以方便快捷限制输入变量类型。