### PR TITLE
紧急修复：env环境变量的布尔值被解析成字符串

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ThinkPHP 6.0
 [![Code Coverage](https://scrutinizer-ci.com/g/top-think/framework/badges/coverage.png?b=6.0)](https://scrutinizer-ci.com/g/top-think/framework/?branch=6.0)
 [![Total Downloads](https://poser.pugx.org/topthink/framework/downloads)](https://packagist.org/packages/topthink/framework)
 [![Latest Stable Version](https://poser.pugx.org/topthink/framework/v/stable)](https://packagist.org/packages/topthink/framework)
-[![PHP Version](https://img.shields.io/badge/php-%3E%3D7.1-8892BF.svg)](http://www.php.net/)
+[![PHP Version](https://img.shields.io/badge/php-%3E%3D7.2.5-8892BF.svg)](http://www.php.net/)
 [![License](https://poser.pugx.org/topthink/framework/license)](https://packagist.org/packages/topthink/framework)
 
 ThinkPHP6.0底层架构采用PHP7.1改写和进一步优化。

--- a/src/think/Env.php
+++ b/src/think/Env.php
@@ -39,7 +39,7 @@ class Env implements ArrayAccess
      */
     public function load(string $file): void
     {
-        $env = parse_ini_file($file, true, INI_SCANNER_RAW) ?: [];
+        $env = parse_ini_file($file, true) ?: [];
         $this->set($env);
     }
 


### PR DESCRIPTION
核心框架版本v6.0.10的一处提交（04403e8ac96e9fe1f50a6aa292503a4d189d64ba）存在严重bug，导致.env环境变量的布尔值标量off和false直接解析为字符串，从而导致调试模式无法关闭。

验证：
APP_DEBUG = false时，halt(env('app_debug'));的值为字符串“false”，从而也是代表true，无法正常关闭调试模式

https://www.kancloud.cn/manual/thinkphp6_0/1037484
![image](https://user-images.githubusercontent.com/11990520/147812818-65276aeb-36ca-4514-a455-0d02417be831.png)
