### PR TITLE
Windows环境下文件访问地址不正确

### DIFF
--- a/src/think/filesystem/driver/Local.php
+++ b/src/think/filesystem/driver/Local.php
@@ -42,8 +42,15 @@ class Local extends Driver
         );
     }
 
+    /**
+     * 获取文件访问地址
+     * @param string $path 文件路径
+     * @return string
+     */
     public function url(string $path): string
     {
+        $path = str_replace('\\', '/', $path);
+
         if (isset($this->config['url'])) {
             return $this->concatPathToUrl($this->config['url'], $path);
         }


### PR DESCRIPTION
将路径中的 `\` 替换为 `/`