### PR TITLE
优化代码使IDE友好

### DIFF
--- a/src/think/Env.php
+++ b/src/think/Env.php
@@ -188,7 +188,7 @@ class Env implements ArrayAccess
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetUnset($name)
+    public function offsetUnset($name): void
     {
         throw new Exception('not support: unset');
     }


### PR DESCRIPTION
因为没有指定返回值为void，所以使用IDE（如`VSCODE`的`PHP intelephense`扩展）时会提示`Method 'think\Env::offsetUnset()' is not compatible with method 'ArrayAccess::offsetUnset()'.`。指定该函数的返回值即可解决该问题。