### PR TITLE
修复当 Shortcut 为 Null 时, strlen 异常

### DIFF
--- a/src/think/console/output/Descriptor.php
+++ b/src/think/console/output/Descriptor.php
@@ -155,7 +155,7 @@ class Descriptor
 
             $this->writeText('<comment>Options:</comment>', $options);
             foreach ($definition->getOptions() as $option) {
-                if (strlen($option->getShortcut()) > 1) {
+                if ($option->getShortcut() && strlen($option->getShortcut()) > 1) {
                     $laterOptions[] = $option;
                     continue;
                 }


### PR DESCRIPTION
PHP 8.1 strlen(): Passing null to parameter #1 ($string) of type string is deprecated