### PR TITLE
fix：添加索引判断

### DIFF
--- a/library/think/route/Rule.php
+++ b/library/think/route/Rule.php
@@ -968,7 +968,7 @@ abstract class Rule
             // [模块/控制器/操作?]参数1=值1&参数2=值2...
             $info = parse_url($url);
             $path = explode('/', $info['path']);
-            parse_str($info['query'], $var);
+            isset($info['query']) && parse_str($info['query'], $var);
         } elseif (strpos($url, '/')) {
             // [模块/控制器/操作]
             $path = explode('/', $url);


### PR DESCRIPTION
当url携带有不正确的参数时，会造成 **query** 下标不存在。