### PR TITLE
请求类型的判断问题

### DIFF
--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -664,7 +664,7 @@ class Request implements ArrayAccess
      */
     public function type(): string
     {
-        $accept = $this->server('HTTP_ACCEPT');
+        $accept = $this->server('HTTP_CONTENT_TYPE');
 
         if (empty($accept)) {
             return '';


### PR DESCRIPTION
判断请求类型用“HTTP_CONTENT_TYPE”或许更合适，“HTTP_ACCEPT”为jquery中ajax的dataType解释是"预期的服务器响应的数据类型"，或者能有一个兼容。