### PR TITLE
tp6的优化过滤函数,兼容php8.1;

### DIFF
--- a/library/think/Request.php
+++ b/library/think/Request.php
@@ -1085,6 +1085,11 @@ class Request
         foreach ($filters as $filter) {
             if (is_callable($filter)) {
                 // 调用函数或者方法过滤
+
+                if(is_null($value)) {
+                    continue;
+                }
+
                 $value = call_user_func($filter, $value);
             } elseif (is_scalar($value)) {
                 if (false !== strpos($filter, '/')) {


### PR DESCRIPTION
当过滤值为null时,不去执行过滤函数;
兼容php8.1`Passing null to parameter #1 ($string) of type string is deprecated`问题