### PR TITLE
FIX:remember缓存读取问题修复

### DIFF
--- a/src/think/cache/Driver.php
+++ b/src/think/cache/Driver.php
@@ -153,8 +153,8 @@ abstract class Driver implements CacheInterface, CacheHandlerInterface
     public function remember(string $name, $value, $expire = null)
     {
         if ($this->has($name)) {
-            if (($cacheValue = $this->get($name)) !== null) {
-                return $cacheValue;
+            if (($hit = $this->get($name)) !== null) {
+                return $hit;
             }
         }
 

--- a/src/think/cache/Driver.php
+++ b/src/think/cache/Driver.php
@@ -153,7 +153,9 @@ abstract class Driver implements CacheInterface, CacheHandlerInterface
     public function remember(string $name, $value, $expire = null)
     {
         if ($this->has($name)) {
-            return $this->get($name);
+            if (($cacheValue = $this->get($name)) !== null) {
+                return $cacheValue;
+            }
         }
 
         $time = time();


### PR DESCRIPTION
在高并发频繁读取缓存的场景下 会出现has判断缓存存在的时候返回true 但是get读取缓存的时候缓存恰好失效(此时返回默认null)  所以需要加上一层判断 当读取缓存失效的时候 执行对应业务逻辑 而不是直接返回null