### PR TITLE
[6.0] 更新 prettify.js 为新的 cdn 地址

### DIFF
--- a/src/tpl/think_exception.tpl
+++ b/src/tpl/think_exception.tpl
@@ -492,7 +492,7 @@ if (!function_exists('echo_value')) {
                 }
             })();
 
-            $.getScript('//cdn.bootcss.com/prettify/r298/prettify.min.js', function(){
+            $.getScript('//cdn.bootcdn.net/ajax/libs/prettify/r298/prettify.min.js', function(){
                 prettyPrint();
             });
         })();


### PR DESCRIPTION
参考 cdn 官网公告：https://www.bootcdn.cn/