### PR TITLE
Bugfix: 修复 PSR-7 Response 用法

### DIFF
--- a/src/think/route/Dispatch.php
+++ b/src/think/route/Dispatch.php
@@ -96,7 +96,7 @@ abstract class Dispatch
         if ($data instanceof Response) {
             $response = $data;
         } elseif ($data instanceof ResponseInterface) {
-            $response = Response::create($data->getBody()->getContents(), 'html', $data->getStatusCode());
+            $response = Response::create((string) $data->getBody(), 'html', $data->getStatusCode());
 
             foreach ($data->getHeaders() as $header => $values) {
                 $response->header([$header => implode(", ", $values)]);


### PR DESCRIPTION
`$response->getBody()->getContents()` 并不能保证拿到完整内容，PSR-7 里的原话：

> Each stream instance will have various capabilities: it can be read-only, write-only, or read-write. It can also allow arbitrary random access (seeking forwards or backwards to any location), or only sequential access (for example in the case of a socket, pipe, or callback-based stream).
>
> Finally, StreamInterface defines a __toString() method to simplify retrieving or emitting the entire body contents at once.
> -- https://www.php-fig.org/psr/psr-7/#13-streams

相关讨论：
- https://github.com/Nyholm/psr7/pull/176