### PR TITLE
先设置header，再获取内容，否则设置的跨域中间件未执行，导致浏览器加载不出内容。

### DIFF
--- a/src/think/Response.php
+++ b/src/think/Response.php
@@ -127,9 +127,6 @@ abstract class Response
      */
     public function send(): void
     {
-        // 处理输出数据
-        $data = $this->getContent();
-
         if (!headers_sent()) {
             if (!empty($this->header)) {
                 // 发送状态码
@@ -144,6 +141,9 @@ abstract class Response
                 $this->cookie->save();
             }
         }
+        
+        // 处理输出数据
+        $data = $this->getContent();
 
         $this->sendData($data);
 


### PR DESCRIPTION
```
/**
     * 发送数据到客户端
     * @access public
     * @return void
     * @throws \InvalidArgumentException
     */
    public function send(): void
    {
   
        // 处理输出数据
        $data = $this->getContent();
        if (!headers_sent()) {
            if (!empty($this->header)) {
                // 发送状态码
                http_response_code($this->code);
                // 发送头部信息
                foreach ($this->header as $name => $val) {
                    header($name . (!is_null($val) ? ':' . $val : ''));
                }
            }

            if ($this->cookie) {
                $this->cookie->save();
            }
        }
     

        $this->sendData($data);

        if (function_exists('fastcgi_finish_request')) {
            // 提高页面响应
            fastcgi_finish_request();
        }
    }

```

原本的时候，如果`getContent`时出现问题，会导致直接抛出异常， 但是对于header的设置没有执行，比如跨域中间件相当于没有执行，导致在浏览器调试时页面空白。