### PR TITLE
修复 think\Validate unique规则 当未提供字段名时 未使用要验证的字段名进行查询 导致sql错误

### DIFF
--- a/src/think/Validate.php
+++ b/src/think/Validate.php
@@ -1146,7 +1146,7 @@ class Validate
                 }
             }
         } elseif (isset($data[$field])) {
-            $map[] = [$key, '=', $data[$field]];
+            $map[] = [$key ?: $field, '=', $data[$field]];
         } else {
             $map = [];
         }


### PR DESCRIPTION
```php

$valdiate = Validate::check([
    'user_phone' => '136***142'
],[
    'user_phone' => 'unique:app\model\User,,1,'
]);
// SELECT `user_guid` FROM `user` WHERE (   = '136***142'  AND `user_guid` <> '1' ) AND `user`.`user_delete_time` IS NULL LIMIT 1
