### PR TITLE
兼容 PHP 8.1

### DIFF
--- a/src/think/console/output/driver/Console.php
+++ b/src/think/console/output/driver/Console.php
@@ -214,12 +214,12 @@ class Console
 
     /**
      * 获取终端模式
-     * @return string <width>x<height> 或 null
+     * @return string <width>x<height>
      */
     private function getMode()
     {
         if (!function_exists('proc_open')) {
-            return;
+            return '';
         }
 
         $descriptorspec = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
@@ -234,7 +234,8 @@ class Console
                 return $matches[2] . 'x' . $matches[1];
             }
         }
-        return;
+
+        return '';
     }
 
     private function stringWidth(string $string): int


### PR DESCRIPTION
改动的代码只有一处调用
Console::getTerminalDimensions()
```
if (preg_match('/^(\d+)x(\d+)$/', $this->getMode(), $matches)) {
    return [(int) $matches[1], (int) $matches[2]];
}
```
相关报错信息
```
PHP Fatal error:  Uncaught think\exception\ErrorException: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in D:\wamp64\www\wsdwl.i0w.cn\vendor\topthink\framework\src\think\console\output\driver\Console.php:175
```