### PR TITLE
修复windows下上传文件失败，原因是$file->getRealPath()取不到路径。

### DIFF
--- a/src/think/filesystem/Driver.php
+++ b/src/think/filesystem/Driver.php
@@ -125,7 +125,7 @@ abstract class Driver
      */
     public function putFileAs(string $path, File $file, string $name, array $options = [])
     {
-        $stream = fopen($file->getRealPath(), 'r');
+        $stream = fopen($file->getPathName(),'r');
         $path   = trim($path . '/' . $name, '/');
 
         $result = $this->putStream($path, $stream, $options);


### PR DESCRIPTION
$stream = fopen($file->getRealPath(), 'r');在windows下上传文件报错，改成 $stream = fopen($file->getPathName(),'r');win 和linux都可以用。