### PR TITLE
Event.php 修复无法注入依赖参数

### DIFF
--- a/src/think/Event.php
+++ b/src/think/Event.php
@@ -266,7 +266,7 @@ class Event
             $call = [$obj, 'handle'];
         }
 
-        return $this->app->invoke($call, [$params]);
+        return $this->app->invoke($call, is_array($params) ? $params : [$params]);
     }
 
 }


### PR DESCRIPTION
会导致无法注入依赖参数