### PR TITLE
允许重置Http的$path为空字符串

### DIFF
--- a/src/think/Http.php
+++ b/src/think/Http.php
@@ -91,7 +91,7 @@ class Http
      */
     public function path(string $path)
     {
-        if (substr($path, -1) != DIRECTORY_SEPARATOR) {
+        if ($path && substr($path, -1) != DIRECTORY_SEPARATOR) {
             $path .= DIRECTORY_SEPARATOR;
         }
 


### PR DESCRIPTION
在workerman环境中如果想复用Http实列，没办法在每次请求时把它的$path重置为空。