### PR TITLE
改进Request类中header方法的返回值

### DIFF
--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -1237,7 +1237,7 @@ class Request implements ArrayAccess
      * @access public
      * @param  string $name header名称
      * @param  string $default 默认值
-     * @return string|array
+     * @return string|array|null
      */
     public function header(string $name = '', string $default = null)
     {


### PR DESCRIPTION
当不存在指定的header时，很明显返回值可能是null，但@return中没有写。在使用phpstan静态检查时发现该问题。