### PR TITLE
fix: 生成模型字段缓存的命令行指令在模型目录存在子目录时异常

### DIFF
--- a/src/think/console/command/optimize/Schema.php
+++ b/src/think/console/command/optimize/Schema.php
@@ -68,6 +68,9 @@ class Schema extends Command
                     continue;
                 }
                 $class = '\\' . $namespace . '\\model\\' . pathinfo($file, PATHINFO_FILENAME);
+                if (!class_exists($class)){
+                    continue;
+                }
                 $this->buildModelSchema($class);
             }
         }


### PR DESCRIPTION
在单应用模式下（多应用模式未测试，从源码看同样存在），使用命令行指令`php think optimize:schema`进行模型字段缓存生成时，如果 app/model 目录下还存在子目录，会抛出异常。

#### 复现方式
（单应用模式），在app/model目录中存在任意子目录
--app
----model
------common
--------BaseModel.php
------User.php
------Article.php

#### 问题分析
问题所在的Schema.php类中大致流程如下
1. 获取所有app/model中的文件及目录
2. （问题所在）遍历文件和目录，将其名称作为类名传给 buildModelSchema() 进行解析
3. new \ReflectionClass() 实例化反射类
4. 判断反射类是否是抽象类、是否继承 think\Model

由于第2步没有排除子目录，所以将目录名作为类名交给 buildModelSchema() 进行解析，导致抛出类不存在的异常。

#### 修复方法
在第2步遍历文件及目录时，先用class_exists()检测类是否存在