### PR TITLE
新增单独关闭路由组内前缀方法closePrefix()

### DIFF
--- a/src/think/route/RuleItem.php
+++ b/src/think/route/RuleItem.php
@@ -115,6 +115,21 @@ class RuleItem extends Rule
 
         return $suffix;
     }
+    
+    /**
+     * 单独关闭前缀
+     * @access public
+     * @param bool $prefix
+     * @return $this
+     */
+    public function closePrefix (bool $prefix = true)
+    {
+        if ($prefix === false) {
+            $this->setOption('prefix', '');
+        }
+
+        return $this;
+    }
 
     /**
      * 路由规则预处理


### PR DESCRIPTION
Route::domain(name: 'api', rule: function () {
    Route::get(rule: '/', route: 'Main/init');
    Route::post(rule: '/auth/login/', route: 'User/login');
    Route::get(rule: '/captcha/create/', route: '\Think\Captcha@create')->closePrefix(false);
})->https()->bind('api')->prefix('api.');

路由绑定域名组预设prefix方法 但是如果某一个路由规则不是指向 api目录下的控制器 需要直接解析指定控制器的时候 就要关闭预设前缀