### PR TITLE
移除基础类中Filesystem申明属性

### DIFF
--- a/src/think/App.php
+++ b/src/think/App.php
@@ -35,7 +35,6 @@ use think\initializer\RegisterService;
  * @property Cookie     $cookie
  * @property Session    $session
  * @property Validate   $validate
- * @property Filesystem $filesystem
  */
 class App extends Container
 {


### PR DESCRIPTION
因Filesystem相关库已剥离，App基础类中的声明属性理应删除