### PR TITLE
修复一对多关联写入字段丢失的问题

### DIFF
--- a/library/think/model/relation/HasMany.php
+++ b/library/think/model/relation/HasMany.php
@@ -242,9 +242,9 @@ class HasMany extends Relation
      */
     public function save($data, $replace = true)
     {
-        $model = $this->make();
+        $model = $this->make($data);
 
-        return $model->replace($replace)->save($data) ? $model : false;
+        return $model->replace($replace)->save() ? $model : false;
     }
 
     /**


### PR DESCRIPTION
### 问题原因
**正常情况（一对一）**
HasOne->save($data)会先
`$data instanceof Model`
然后执行
`$data = $data->getData()`
顺利关联写入

**出错情况（一对多）**
HasMany->save($data)不做任何处理，获取外键数据后，直接将实例传给Model->save()，导致关联写入时外键以外的字段被全部丢弃，造成关联写入失败的问题

修复后，一对多就可以正常关联写入了。
有个问题顺便问以下，为什么一对多的写入默认是replace？没太明白有什么用意