### PR TITLE
fix: 修正定义全局的查询范围时的回调名称

### DIFF
--- a/library/think/db/Query.php
+++ b/library/think/db/Query.php
@@ -2320,7 +2320,7 @@ class Query
         if ($this->model) {
             // 检查模型类的查询范围方法
             foreach ($scope as $name) {
-                $method = 'scope' . trim($name);
+                $method = 'scope' . Loader::parseName(trim($name), 1);
 
                 if (method_exists($this->model, $method)) {
                     call_user_func_array([$this->model, $method], $args);


### PR DESCRIPTION
如当定义`$globalScope = ['system_user_id']` 时：查询范围的回函数名应为：`scopeSystemUserId`。

- [查询范围文档](https://www.kancloud.cn/manual/thinkphp5_1/354053)