### PR TITLE
fix: container绑定参数时可变参数处理

### DIFF
--- a/src/think/Container.php
+++ b/src/think/Container.php
@@ -445,7 +445,9 @@ class Container implements ContainerInterface, ArrayAccess, IteratorAggregate, C
             $lowerName      = Str::snake($name);
             $reflectionType = $param->getType();
 
-            if ($reflectionType && $reflectionType->isBuiltin() === false) {
+            if ($param->isVariadic()) {
+                return array_merge($args, array_values($vars));
+            } elseif ($reflectionType && $reflectionType->isBuiltin() === false) {
                 $args[] = $this->getObjectParam($reflectionType->getName(), $vars);
             } elseif (1 == $type && !empty($vars)) {
                 $args[] = array_shift($vars);


### PR DESCRIPTION
```
app()->invoke(function ($index, ...$args) {
    var_dump(func_get_args());
}, [1, 2, 3]);

输出：
array(2) {
  [0]=>
  int(1)
  [1]=>
  int(2)
}
```
修复容器绑定参数时，可变参数参数丢失问题。