### PR TITLE
兼容PHP8.2

### DIFF
--- a/src/think/console/output/Ask.php
+++ b/src/think/console/output/Ask.php
@@ -295,7 +295,7 @@ class Ask
             $width = max(array_map('strlen', array_keys($this->question->getChoices())));
 
             foreach ($this->question->getChoices() as $key => $value) {
-                $this->output->writeln(sprintf("  [<comment>%-${width}s</comment>] %s", $key, $value));
+                $this->output->writeln(sprintf("  [<comment>%-{$width}s</comment>] %s", $key, $value));
             }
         }
 

--- a/src/think/console/output/Descriptor.php
+++ b/src/think/console/output/Descriptor.php
@@ -219,7 +219,7 @@ class Descriptor
             $width = $this->getColumnWidth($description->getNamespaces());
 
             foreach ($description->getCommands() as $command) {
-                $this->writeText(sprintf("%-${width}s %s", $command->getName(), $command->getDescription()), $options);
+                $this->writeText(sprintf("%-{$width}s %s", $command->getName(), $command->getDescription()), $options);
                 $this->writeText("\n");
             }
         } else {


### PR DESCRIPTION
PHP8.2中，已弃用 `${}` 字符串插值，故应将美元符号移到括号内部以解决报错