### PR TITLE
fix: 用 {$var} 代替PHP8.2中弃用的 ${var} 方式

### DIFF
--- a/src/think/console/output/Ask.php
+++ b/src/think/console/output/Ask.php
@@ -295,7 +295,7 @@ class Ask
             $width = max(array_map('strlen', array_keys($this->question->getChoices())));
 
             foreach ($this->question->getChoices() as $key => $value) {
-                $this->output->writeln(sprintf("  [<comment>%-${width}s</comment>] %s", $key, $value));
+                $this->output->writeln(sprintf("  [<comment>%-{$width}s</comment>] %s", $key, $value));
             }
         }
 

--- a/src/think/console/output/Descriptor.php
+++ b/src/think/console/output/Descriptor.php
@@ -219,7 +219,7 @@ class Descriptor
             $width = $this->getColumnWidth($description->getNamespaces());
 
             foreach ($description->getCommands() as $command) {
-                $this->writeText(sprintf("%-${width}s %s", $command->getName(), $command->getDescription()), $options);
+                $this->writeText(sprintf("%-{$width}s %s", $command->getName(), $command->getDescription()), $options);
                 $this->writeText("\n");
             }
         } else {


### PR DESCRIPTION
解决运行 php think 命令时的报错信息