### PR TITLE
修复 控制台打印部分中文乱码

### DIFF
--- a/src/think/console/output/Descriptor.php
+++ b/src/think/console/output/Descriptor.php
@@ -345,7 +345,7 @@ class Descriptor
         $replace = PHP_EOL . str_repeat(' ', $space_length);
 
         // 不能使用 /\s*\R\s*/u，如果描述存在 U+0085 字符会导致 preg_replace 返回空，参考：https://www.php.net/manual/zh/reference.pcre.pattern.modifiers.php
-        // 使用 (\r\n|\n|\r|\f) 和 while 替换 \R，参考：https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions#Newline/linebreak_options
+        // 使用 (\r\n|\n|\r|\f) 和 foreach 替换 \R，参考：https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions#Newline/linebreak_options
         $desc = preg_replace('/\s*(\r\n|\n|\r|\f)\s*/', $replace, $desc);
 
         $next_line = chr(0x85);


### PR DESCRIPTION
### 问题
![修复前](https://user-images.githubusercontent.com/39550254/215311067-d9ee03b1-6711-4ad7-a100-b9a181b04809.jpg)

### 复现文件 
```
app/command/Test.php
```
```php
<?php

declare(strict_types=1);

namespace app\command;

use think\console\Command;
use think\console\Input;
use think\console\Output;

class Test extends Command
{
    protected function configure()
    {
        $this->setName('test')
            ->addArgument('yuan', null, '元')
            ->addArgument('guan', null, '关')
            ->addOption('gon', null, null, '共')
            ->addOption('lan', null, null, '兰')
            ->setDescription('the app\command\test command');
    }

    protected function execute(Input $input, Output $output)
    {
    }
}

```

### 复现命令
```shell
$ php think test -h
```
### 修复后
![修复后](https://user-images.githubusercontent.com/39550254/215311071-0584173b-9d05-404a-9e4a-3c7904094b2b.jpg)
