### PR TITLE
更新单元测试的 PHP 版本、更新徽章

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 8.0
+    - php: 8.1
+    - php: 8.2
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ ThinkPHP 6.1
 
 [![Total Downloads](https://poser.pugx.org/topthink/framework/downloads)](https://packagist.org/packages/topthink/framework)
 [![Latest Stable Version](https://poser.pugx.org/topthink/framework/v/stable)](https://packagist.org/packages/topthink/framework)
-[![PHP Version](https://img.shields.io/packagist/dependency-v/topthink/framework/php)](http://www.php.net/)
-[![License](https://poser.pugx.org/topthink/framework/license)](https://packagist.org/packages/topthink/framework)
+[![PHP Version](https://img.shields.io/packagist/dependency-v/topthink/framework/php?version=8.0.x-dev)](http://www.php.net/)
+[![License](https://poser.pugx.org/topthink/framework/license?version=8.0.x-dev)](https://packagist.org/packages/topthink/framework)
 
 
 [官方服务](https://www.topthink.com) | [`ThinkAPI`——官方统一API](https://doc.topthink.com/think-api)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 ThinkPHP 6.1
 ===============
 
-[![Build Status](https://travis-ci.org/top-think/framework.svg?branch=6.1)](https://travis-ci.org/top-think/framework)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/top-think/framework/badges/quality-score.png?b=6.1)](https://scrutinizer-ci.com/g/top-think/framework/?branch=6.0)
-[![Code Coverage](https://scrutinizer-ci.com/g/top-think/framework/badges/coverage.png?b=6.1)](https://scrutinizer-ci.com/g/top-think/framework/?branch=6.1)
 [![Total Downloads](https://poser.pugx.org/topthink/framework/downloads)](https://packagist.org/packages/topthink/framework)
 [![Latest Stable Version](https://poser.pugx.org/topthink/framework/v/stable)](https://packagist.org/packages/topthink/framework)
 [![PHP Version](https://img.shields.io/packagist/dependency-v/topthink/framework/php)](http://www.php.net/)

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 ThinkPHP 6.1
 ===============
 
-[![Build Status](https://travis-ci.org/top-think/framework.svg?branch=6.0)](https://travis-ci.org/top-think/framework)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/top-think/framework/badges/quality-score.png?b=6.0)](https://scrutinizer-ci.com/g/top-think/framework/?branch=6.0)
-[![Code Coverage](https://scrutinizer-ci.com/g/top-think/framework/badges/coverage.png?b=6.0)](https://scrutinizer-ci.com/g/top-think/framework/?branch=6.0)
+[![Build Status](https://travis-ci.org/top-think/framework.svg?branch=6.1)](https://travis-ci.org/top-think/framework)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/top-think/framework/badges/quality-score.png?b=6.1)](https://scrutinizer-ci.com/g/top-think/framework/?branch=6.0)
+[![Code Coverage](https://scrutinizer-ci.com/g/top-think/framework/badges/coverage.png?b=6.1)](https://scrutinizer-ci.com/g/top-think/framework/?branch=6.1)
 [![Total Downloads](https://poser.pugx.org/topthink/framework/downloads)](https://packagist.org/packages/topthink/framework)
 [![Latest Stable Version](https://poser.pugx.org/topthink/framework/v/stable)](https://packagist.org/packages/topthink/framework)
-[![PHP Version](https://img.shields.io/badge/php-%3E%3D7.1-8892BF.svg)](http://www.php.net/)
+[![PHP Version](https://img.shields.io/packagist/dependency-v/topthink/framework/php)](http://www.php.net/)
 [![License](https://poser.pugx.org/topthink/framework/license)](https://packagist.org/packages/topthink/framework)
 
 


### PR DESCRIPTION
* 单元测试增加 php 8.1和8.2
* 更新 README.md 中的 PHP 版本徽章
* 删除 travis ci 和 Scrutinizer 的徽章（收费原因，没有 6.1 版本的数据）