### PR TITLE
Fix: 参数类型为多个时导致的报错

### DIFF
--- a/src/think/Container.php
+++ b/src/think/Container.php
@@ -447,7 +447,7 @@ class Container implements ContainerInterface, ArrayAccess, IteratorAggregate, C
 
             if ($param->isVariadic()) {
                 return array_merge($args, array_values($vars));
-            } elseif ($reflectionType && $reflectionType->isBuiltin() === false) {
+            } elseif ($reflectionType && $reflectionType instanceof \ReflectionNamedType && $reflectionType->isBuiltin() === false) {
                 $args[] = $this->getObjectParam($reflectionType->getName(), $vars);
             } elseif (1 == $type && !empty($vars)) {
                 $args[] = array_shift($vars);


### PR DESCRIPTION
多个类型时，reflectionType为ReflectionUnionType
ReflectionUnionType没有isBuiltin
`public function mark(int|string $id): array{

}`