### PR TITLE
日志级别支持 * 记录所有级别的日志

### DIFF
--- a/src/think/log/Channel.php
+++ b/src/think/log/Channel.php
@@ -80,7 +80,7 @@ class Channel implements LoggerInterface
      */
     public function record($msg, string $type = 'info', array $context = [], bool $lazy = true)
     {
-        if ($this->close || (!empty($this->allow) && !in_array($type, $this->allow))) {
+        if ($this->close || (!empty($this->allow) && (!in_array($type, $this->allow) || !in_array('*', $this->allow)))) {
             return $this;
         }
 


### PR DESCRIPTION
一些情况可能需要将所有日志输出，例如调试时，或部分生产环境下的需要。

如果手动填写所有日志级别容易遗漏，到文档复制显得比较繁琐，所以想着是否可以通过在配置中添加 `*` 快速设置允许所有日志级别的记录？
