### PR TITLE
fix: 修复发生错误中止时，日志没有写入、中间件end回调没有执行

### DIFF
--- a/src/think/initializer/Error.php
+++ b/src/think/initializer/Error.php
@@ -55,7 +55,9 @@ class Error
         if ($this->app->runningInConsole()) {
             $handler->renderForConsole(new ConsoleOutput, $e);
         } else {
-            $handler->render($this->app->request, $e)->send();
+            $response = $handler->render($this->app->request, $e);
+            $response->send();
+            $this->app->http->end($response);
         }
     }
 


### PR DESCRIPTION
修复内容：在PHP发生错误中止时，内存中的日志没有写入到文件，中间件end回调没有执行。

复现如下：
```php
<?php
namespace app\index\controller;

use app\BaseController;

class Index extends BaseController
{
    public function index()
    {
        app('log')->record('这个日志不会被写入');  // 这是一个发生错误前，写入到内存的日志
        require_once './test.php';   // (test.php文件不存在时) 这是一个不可抛出的 shutdown 错误
        return 'shutdown test';
    }
}

```

解决思路：
路由分发到控制器后发生的所有Error和Exception都被中间件队列使用try catch捕获了Throwable，不会执行到set_exception_handler、set_error_handler这两个PHP函数, 所以正常走入口文件index.php的$response->send();$http->end($response); 
当PHP代码发生错误（不可抛出的错误）中止时，不能被Throwable捕获，但被register_shutdown_function捕获，进而由think\initializer\Error->appShutdown()处理，但是处理逻辑没有执行http的end回调。


