### PR TITLE
fix 日志删除，删除的不是最早的那个文件

### DIFF
--- a/src/think/log/driver/File.php
+++ b/src/think/log/driver/File.php
@@ -139,6 +139,9 @@ class File implements LogHandlerInterface
 
             try {
                 if (count($files) > $this->config['max_files']) {
+                    usort($files, function ($a, $b) {
+                        return   filemtime($a) - filemtime($b);
+                    });
                     set_error_handler(function ($errno, $errstr, $errfile, $errline) {});
                     unlink($files[0]);
                     restore_error_handler();

--- a/src/think/log/driver/File.php
+++ b/src/think/log/driver/File.php
@@ -140,7 +140,7 @@ class File implements LogHandlerInterface
             try {
                 if (count($files) > $this->config['max_files']) {
                     usort($files, function ($a, $b) {
-                        return   filemtime($a) - filemtime($b);
+                        return filemtime($b) - filemtime($a);
                     });
                     set_error_handler(function ($errno, $errstr, $errfile, $errline) {});
                     unlink($files[0]);


### PR DESCRIPTION
日志文件数大于配置的个数时，删除的不一定是最早的那个文件，而是glob返回的第一个文件