### PR TITLE
优化字段唯一验证，自定义主键名时排除ID不再为必填

### DIFF
--- a/src/think/Validate.php
+++ b/src/think/Validate.php
@@ -1154,7 +1154,7 @@ class Validate
         $pk = !empty($rule[3]) ? $rule[3] : $db->getPk();
 
         if (is_string($pk)) {
-            if (isset($rule[2])) {
+            if (!empty($rule[2])) {
                 $map[] = [$pk, '<>', $rule[2]];
             } elseif (isset($data[$pk])) {
                 $map[] = [$pk, '<>', $data[$pk]];


### PR DESCRIPTION
优化字段唯一验证，自定义主键名时排除ID不再为必填
当排除ID为空的时候自动根据传入的主键名字段获取对应的值