### PR TITLE
Update RuleGroup.php

### DIFF
--- a/src/think/route/RuleGroup.php
+++ b/src/think/route/RuleGroup.php
@@ -268,7 +268,9 @@ class RuleGroup extends Rule
         $items = [];
 
         foreach ($rules as $key => $val) {
-            $item = $val[1];
+            // $item = is_array($val) ? $val[1] : $val;
+            // $item = $val[1];
+            $item = $val;
             if ($item instanceof RuleItem) {
                 $rule = $depr . str_replace('/', $depr, $item->getRule());
                 if ($depr == $rule && $depr != $url) {


### PR DESCRIPTION
路由分组报Cannot use object of type think\route\RuleItem as array