### PR TITLE
优化配置初始化时机过晚问题

### DIFF
--- a/library/think/App.php
+++ b/library/think/App.php
@@ -331,11 +331,12 @@ class App extends Container
 
         if ($module) {
             // 对容器中的对象实例进行配置更新
-            $this->containerConfigUpdate($module);
+            $this->lang->load($this->appPath . $module . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . $this->request->langset() . '.php');
         }
+        $this->containerConfigUpdate();
     }
 
-    protected function containerConfigUpdate($module)
+    protected function containerConfigUpdate()
     {
         $config = $this->config->get();
 
@@ -354,10 +355,7 @@ class App extends Container
         $this->session->setConfig($config['session']);
         $this->debug->setConfig($config['trace']);
         $this->cache->init($config['cache'], true);
-
-        // 加载当前模块语言包
-        $this->lang->load($this->appPath . $module . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . $this->request->langset() . '.php');
-
+       
         // 模块请求缓存检查
         $this->checkRequestCache(
             $config['app']['request_cache'],


### PR DESCRIPTION
框架会多次调用`init($module = '')`方法，但只有`$module`不为空的时候才会调用`containerConfigUpdate`去初始化配置信息。这个阶段差不多已经是`module_init`的时候了，这导致在这之前使用一些组件，配置信息是未初始化的。比如监听了`app_init`事件，在此事件里面使用了cache缓存组件，但这个时候cache是没有加载配置的，默认是使用file驱动。但其实配置里面是使用`complex`组合模式，默认为redis驱动。这样会导致一个问题，我在某控制器里使用存了一个值，使用的是redis驱动，但我在app_init阶段读取这个值，却使用file驱动。另外，官方的`think-throttle`限流组件，构造方法里为`public function __construct(Cache $cache, Config $config)`，如果是作为全局中间件，首次App::init('')时，`Middleware->import()`加载此中间件的时候就初始化了cache，同样的使用了file驱动。使用file缓存限流，只能说有点坑。。
```
    in Cache.php line 87
    at Cache->init() in Cache.php line 49
    at Cache->__construct() in Cache.php line 104
    at Cache::__make()
    at ReflectionMethod->invokeArgs() in Container.php line 431
    at Container->invokeClass() in Container.php line 284
    at Container->make() in Container.php line 554
    at Container->getObjectParam() in Container.php line 489
    at Container->parseParams() in Container.php line 467
    at Container->bindParams() in Container.php line 437
    at Container->invokeClass() in Container.php line 284
    at Container->make() in Middleware.php line 171
    at Middleware->buildMiddleware() in Middleware.php line 67
    at Middleware->add() in Middleware.php line 51
    at Middleware->import() in App.php line 302
    at App->init() in App.php line 211
    at App->initialize() in App.php line 380
    at App->run() in index.php line 21

```