### PR TITLE
修复开启route_rule_merge后报错的问题

### DIFF
--- a/src/think/route/RuleGroup.php
+++ b/src/think/route/RuleGroup.php
@@ -263,8 +263,7 @@ class RuleGroup extends Rule
         $regex = [];
         $items = [];
 
-        foreach ($rules as $key => $val) {
-            $item = $val[1];
+        foreach ($rules as $key => $item) {
             if ($item instanceof RuleItem) {
                 $rule = $depr . str_replace('/', $depr, $item->getRule());
                 if ($depr == $rule && $depr != $url) {


### PR DESCRIPTION
开启了route.php中的route_rule_merge配置以后，该代码无法通过，查看了修改历史，发现是framework/src/think/route/RuleGroup.php中的addRuleItem代码修改导致的