### PR TITLE
Feat: 支持设置控制台默认执行用户

### DIFF
--- a/src/think/Console.php
+++ b/src/think/Console.php
@@ -93,6 +93,12 @@ class Console
         //加载指令
         $this->loadCommands();
 
+        // 设置执行用户
+        $user = $this->app->config->get('console.user');
+        if (!empty($user)) {
+            $this->setUser($user);
+        }
+
         $this->start();
     }
 


### PR DESCRIPTION
很多人使用 `root` 用户去使用自定义命令，导致运行后，日志文件的用户为 `root`，导致 WEB 情景下的 `www` 用户无法写入日志，影响网站正常运行。
支持在配置文件设置用户，可以降低设置难度，减少这类事故。