### PR TITLE
日志文件数量限制优先删除最旧的日志文件

### DIFF
--- a/src/think/log/driver/File.php
+++ b/src/think/log/driver/File.php
@@ -139,8 +139,17 @@ class File implements LogHandlerInterface
 
             try {
                 if (count($files) > $this->config['max_files']) {
+                    $oldest_file = $files[0];
+                    $oldest_mtime = filemtime($oldest_file);
+                    for ($i = 1; $i < count($files); $i++) {
+                        $mtime = filemtime($files[$i]);
+                        if ($mtime < $oldest_mtime) {
+                            $oldest_file = $files[$i];
+                            $oldest_mtime = $mtime;
+                        }
+                    }
                     set_error_handler(function ($errno, $errstr, $errfile, $errline) {});
-                    unlink($files[0]);
+                    unlink($oldest_file);
                     restore_error_handler();
                 }
             } catch (\Exception $e) {


### PR DESCRIPTION
`glob($this->config['path'] . '*.log')` 会按照文件名排序返回，删除第一个文件不太合理。#2877