### PR TITLE
Feat: Use PHP_BINARY instead of php

### DIFF
--- a/src/think/console/command/RunServer.php
+++ b/src/think/console/command/RunServer.php
@@ -81,7 +81,7 @@ class RunServer extends Command
         }
 
         $path = PHP_BINDIR . DIRECTORY_SEPARATOR . 'php';
-        if (file_exists($path) && is_executable(PHP_BINARY)) {
+        if (file_exists($path) && is_executable($path)) {
             return $path;
         }
 

--- a/src/think/console/command/RunServer.php
+++ b/src/think/console/command/RunServer.php
@@ -56,7 +56,8 @@ class RunServer extends Command
         }
 
         $command = sprintf(
-            'php -S %s:%d -t %s %s',
+            '%s -S %s:%d -t %s %s',
+            $this->getPhpBinary(),
             $host,
             $port,
             escapeshellarg($root),
@@ -67,6 +68,24 @@ class RunServer extends Command
         $output->writeln(sprintf('You can exit with <info>`CTRL-C`</info>'));
         $output->writeln(sprintf('Document root is: %s', $root));
         passthru($command);
+    }
+
+    /**
+     * 获取 PHP 路径
+     * @return string
+     */
+    protected function getPhpBinary(): string
+    {
+        if (is_executable(PHP_BINARY)) {
+            return PHP_BINARY;
+        }
+
+        $path = PHP_BINDIR . DIRECTORY_SEPARATOR . 'php';
+        if (file_exists($path) && is_executable(PHP_BINARY)) {
+            return $path;
+        }
+
+        return 'php';
     }
 
 }

--- a/src/think/console/command/RunServer.php
+++ b/src/think/console/command/RunServer.php
@@ -57,7 +57,7 @@ class RunServer extends Command
 
         $command = sprintf(
             '%s -S %s:%d -t %s %s',
-            $this->getPhpBinary(),
+            PHP_BINARY,
             $host,
             $port,
             escapeshellarg($root),
@@ -69,23 +69,4 @@ class RunServer extends Command
         $output->writeln(sprintf('Document root is: %s', $root));
         passthru($command);
     }
-
-    /**
-     * 获取 PHP 路径
-     * @return string
-     */
-    protected function getPhpBinary(): string
-    {
-        if (is_executable(PHP_BINARY)) {
-            return PHP_BINARY;
-        }
-
-        $path = PHP_BINDIR . DIRECTORY_SEPARATOR . 'php';
-        if (file_exists($path) && is_executable($path)) {
-            return $path;
-        }
-
-        return 'php';
-    }
-
 }


### PR DESCRIPTION
Windows 系统，如果没把 php 加到 `PATH` 系统环境变量里时，执行 `think run` 会报 `'php' is not recognized as an internal or external command`。

```
D:\wamp64\bin\php\php8.1.18\php.exe think run -vvv
```
```
ThinkPHP Development server is started On <http://0.0.0.0:8000/>
You can exit with `CTRL-C`
Document root is: D:\wamp64\www\tp80.i0w.cn\public
'php' is not recognized as an internal or external command,
operable program or batch file.
```