### PR TITLE
应由php本身指定报告错误等级

### DIFF
--- a/src/think/initializer/Error.php
+++ b/src/think/initializer/Error.php
@@ -35,7 +35,6 @@ class Error
     public function init(App $app)
     {
         $this->app = $app;
-        error_reporting(E_ALL);
         set_error_handler([$this, 'appError']);
         set_exception_handler([$this, 'appException']);
         register_shutdown_function([$this, 'appShutdown']);


### PR DESCRIPTION
不同环境的错误等级应该是不同的,不应由运行时指定