### PR TITLE
为requre获取参数方法指定正确的filter类型

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -246,9 +246,9 @@ if (!function_exists('halt')) {
 if (!function_exists('input')) {
     /**
      * 获取输入数据 支持默认值和过滤
-     * @param string $key     获取的变量名
+     * @param string $key 获取的变量名
      * @param mixed  $default 默认值
-     * @param string $filter  过滤方法
+     * @param string|array|null $filter 过滤方法
      * @return mixed
      */
     function input(string $key = '', $default = null, $filter = '')

--- a/src/think/Request.php
+++ b/src/think/Request.php
@@ -848,11 +848,11 @@ class Request implements ArrayAccess
      * 获取当前请求的参数
      * @access public
      * @param  string|array $name 变量名
-     * @param  mixed        $default 默认值
-     * @param  string|array $filter 过滤方法
+     * @param  mixed $default 默认值
+     * @param  string|array|null $filter 过滤方法
      * @return mixed
      */
-    public function param($name = '', $default = null, $filter = '')
+    public function param($name = '', $default = null, string|array|null $filter = '')
     {
         if (empty($this->mergeParam)) {
             $method = $this->method(true);
@@ -881,10 +881,10 @@ class Request implements ArrayAccess
      * 获取包含文件在内的请求参数
      * @access public
      * @param  string|array $name 变量名
-     * @param  string|array $filter 过滤方法
+     * @param  string|array|null $filter 过滤方法
      * @return mixed
      */
-    public function all(string|array $name = '', string|array $filter = '')
+    public function all(string|array $name = '', string|array|null $filter = '')
     {
         $data = array_merge($this->param(), $this->file() ?: []);
 
@@ -937,10 +937,10 @@ class Request implements ArrayAccess
      * @access public
      * @param  string|array|bool $name 变量名
      * @param  mixed        $default 默认值
-     * @param  string|array $filter 过滤方法
+     * @param  string|array|null $filter 过滤方法
      * @return mixed
      */
-    public function route(string|array|bool $name = '', $default = null, string|array $filter = '')
+    public function route(string|array|bool $name = '', $default = null, string|array|null $filter = '')
     {
         if (is_array($name)) {
             return $this->only($name, $this->route, $filter);
@@ -954,10 +954,10 @@ class Request implements ArrayAccess
      * @access public
      * @param  string|array|bool $name 变量名
      * @param  mixed        $default 默认值
-     * @param  string|array $filter 过滤方法
+     * @param  string|array|null $filter 过滤方法
      * @return mixed
      */
-    public function get(string|array|bool $name = '', $default = null, string|array $filter = '')
+    public function get(string|array|bool $name = '', $default = null, string|array|null $filter = '')
     {
         if (is_array($name)) {
             return $this->only($name, $this->get, $filter);
@@ -983,10 +983,10 @@ class Request implements ArrayAccess
      * @access public
      * @param  bool|string|array $name 变量名
      * @param  mixed        $default 默认值
-     * @param  string|array $filter 过滤方法
+     * @param  string|array|null $filter 过滤方法
      * @return mixed
      */
-    public function post(string|array|bool $name = '', $default = null, string|array $filter = '')
+    public function post(string|array|bool $name = '', $default = null, string|array|null $filter = '')
     {
         if (is_array($name)) {
             return $this->only($name, $this->post, $filter);
@@ -1000,10 +1000,10 @@ class Request implements ArrayAccess
      * @access public
      * @param  string|array|bool $name 变量名
      * @param  mixed        $default 默认值
-     * @param  string|array $filter 过滤方法
+     * @param  string|array|null $filter 过滤方法
      * @return mixed
      */
-    public function put(string|array|bool $name = '', $default = null, string|array $filter = '')
+    public function put(string|array|bool $name = '', $default = null, string|array|null $filter = '')
     {
         if (is_array($name)) {
             return $this->only($name, $this->put, $filter);
@@ -1030,10 +1030,10 @@ class Request implements ArrayAccess
      * @access public
      * @param  mixed        $name 变量名
      * @param  mixed        $default 默认值
-     * @param  string|array $filter 过滤方法
+     * @param  string|array|null $filter 过滤方法
      * @return mixed
      */
-    public function delete(string|array|bool $name = '', $default = null, string|array $filter = '')
+    public function delete(string|array|bool $name = '', $default = null, string|array|null $filter = '')
     {
         return $this->put($name, $default, $filter);
     }
@@ -1043,10 +1043,10 @@ class Request implements ArrayAccess
      * @access public
      * @param  mixed        $name 变量名
      * @param  mixed        $default 默认值
-     * @param  string|array $filter 过滤方法
+     * @param  string|array|null $filter 过滤方法
      * @return mixed
      */
-    public function patch(string|array|bool $name = '', $default = null, string|array $filter = '')
+    public function patch(string|array|bool $name = '', $default = null, string|array|null $filter = '')
     {
         return $this->put($name, $default, $filter);
     }
@@ -1056,10 +1056,10 @@ class Request implements ArrayAccess
      * @access public
      * @param  string|array $name 数据名称
      * @param  mixed        $default 默认值
-     * @param  string|array $filter 过滤方法
+     * @param  string|array|null $filter 过滤方法
      * @return mixed
      */
-    public function request(string|array|bool $name = '', $default = null, string|array $filter = '')
+    public function request(string|array|bool $name = '', $default = null, string|array|null $filter = '')
     {
         if (is_array($name)) {
             return $this->only($name, $this->request, $filter);
@@ -1103,10 +1103,10 @@ class Request implements ArrayAccess
      * @access public
      * @param  mixed        $name 数据名称
      * @param  string       $default 默认值
-     * @param  string|array $filter 过滤方法
+     * @param  string|array|null $filter 过滤方法
      * @return mixed
      */
-    public function cookie(string $name = '', $default = null, $filter = '')
+    public function cookie(string $name = '', $default = null, string|array|null $filter = '')
     {
         if (!empty($name)) {
             $data = $this->getData($this->cookie, $name, $default);
@@ -1252,13 +1252,13 @@ class Request implements ArrayAccess
     /**
      * 获取变量 支持过滤和默认值
      * @access public
-     * @param  array        $data 数据源
+     * @param  array $data 数据源
      * @param  string|false $name 字段名
-     * @param  mixed        $default 默认值
-     * @param  string|array $filter 过滤函数
+     * @param  mixed $default 默认值
+     * @param  string|array|null $filter 过滤函数
      * @return mixed
      */
-    public function input(array $data = [], string|bool $name = '', $default = null, string|array $filter = '')
+    public function input(array $data = [], string|bool $name = '', $default = null, string|array|null $filter = '')
     {
         if (false === $name) {
             // 获取原始数据
@@ -1462,12 +1462,12 @@ class Request implements ArrayAccess
     /**
      * 获取指定的参数
      * @access public
-     * @param  array        $name 变量名
-     * @param  mixed        $data 数据或者变量类型
-     * @param  string|array $filter 过滤方法
+     * @param  array $name 变量名
+     * @param  mixed $data 数据或者变量类型
+     * @param  string|array|null $filter 过滤方法
      * @return array
      */
-    public function only(array $name, $data = 'param', $filter = ''): array
+    public function only(array $name, $data = 'param', string|array|null $filter = ''): array
     {
         $data = is_array($data) ? $data : $this->$data();
 

--- a/src/think/facade/Request.php
+++ b/src/think/facade/Request.php
@@ -52,29 +52,29 @@ use think\route\Rule;
  * @method static bool isOptions() 是否为OPTIONS请求
  * @method static bool isCli() 是否为cli
  * @method static bool isCgi() 是否为cgi
- * @method static mixed param(string|array $name = '', mixed $default = null, string|array $filter = '') 获取当前请求的参数
+ * @method static mixed param(string|array $name = '', mixed $default = null, string|array|null $filter = '') 获取当前请求的参数
  * @method static \think\Request setRule(Rule $rule) 设置路由变量
  * @method static Rule|null rule() 获取当前路由对象
  * @method static \think\Request setRoute(array $route) 设置路由变量
- * @method static mixed route(string|array $name = '', mixed $default = null, string|array $filter = '') 获取路由参数
- * @method static mixed get(string|array $name = '', mixed $default = null, string|array $filter = '') 获取GET参数
+ * @method static mixed route(string|array $name = '', mixed $default = null, string|array|null $filter = '') 获取路由参数
+ * @method static mixed get(string|array $name = '', mixed $default = null, string|array|null $filter = '') 获取GET参数
  * @method static mixed middleware(mixed $name, mixed $default = null) 获取中间件传递的参数
- * @method static mixed post(string|array $name = '', mixed $default = null, string|array $filter = '') 获取POST参数
- * @method static mixed put(string|array $name = '', mixed $default = null, string|array $filter = '') 获取PUT参数
- * @method static mixed delete(mixed $name = '', mixed $default = null, string|array $filter = '') 设置获取DELETE参数
- * @method static mixed patch(mixed $name = '', mixed $default = null, string|array $filter = '') 设置获取PATCH参数
- * @method static mixed request(string|array $name = '', mixed $default = null, string|array $filter = '') 获取request变量
+ * @method static mixed post(string|array $name = '', mixed $default = null, string|array|null $filter = '') 获取POST参数
+ * @method static mixed put(string|array $name = '', mixed $default = null, string|array|null $filter = '') 获取PUT参数
+ * @method static mixed delete(mixed $name = '', mixed $default = null, string|array|null $filter = '') 设置获取DELETE参数
+ * @method static mixed patch(mixed $name = '', mixed $default = null, string|array|null $filter = '') 设置获取PATCH参数
+ * @method static mixed request(string|array $name = '', mixed $default = null, string|array|null $filter = '') 获取request变量
  * @method static mixed env(string $name = '', string $default = null) 获取环境变量
  * @method static mixed session(string $name = '', string $default = null) 获取session数据
- * @method static mixed cookie(mixed $name = '', string $default = null, string|array $filter = '') 获取cookie参数
+ * @method static mixed cookie(mixed $name = '', string $default = null, string|array|null $filter = '') 获取cookie参数
  * @method static mixed server(string $name = '', string $default = '') 获取server参数
  * @method static null|array|UploadedFile file(string $name = '') 获取上传的文件信息
  * @method static string|array header(string $name = '', string $default = null) 设置或者获取当前的Header
- * @method static mixed input(array $data = [], string|false $name = '', mixed $default = null, string|array $filter = '') 获取变量 支持过滤和默认值
+ * @method static mixed input(array $data = [], string|false $name = '', mixed $default = null, string|array|null $filter = '') 获取变量 支持过滤和默认值
  * @method static mixed filter(mixed $filter = null) 设置或获取当前的过滤规则
  * @method static mixed filterValue(mixed &$value, mixed $key, array $filters) 递归过滤给定的值
  * @method static bool has(string $name, string $type = 'param', bool $checkEmpty = false) 是否存在某个请求参数
- * @method static array only(array $name, mixed $data = 'param', string|array $filter = '') 获取指定的参数
+ * @method static array only(array $name, mixed $data = 'param', string|array|null $filter = '') 获取指定的参数
  * @method static mixed except(array $name, string $type = 'param') 排除指定参数获取
  * @method static bool isSsl() 当前是否ssl
  * @method static bool isJson() 当前是否JSON请求


### PR DESCRIPTION
从代码`src\think\Request.php`来看：
```
    protected function getFilter($filter, $default): array
    {
        if (is_null($filter)) {
            $filter = [];
        } else {
            $filter = $filter ?: $this->filter;
            if (is_string($filter) && !str_contains($filter, '/')) {
                $filter = explode(',', $filter);
            } else {
                $filter = (array) $filter;
            }
        }

        $filter[] = $default;

        return $filter;
    }
```

filter参数是支持null的，意味着不调用任何过滤函数。
并且filter应该支持null，虽然空数组也能达到效果，但null更具有实际意义。
但在8.0版本中，并不接受null，如果不进行声名则无法再php8.0中正确运行，本次提交为修复该错误。

```
think\\Request::input(): Argument #4 ($filter) must be of type array|string, null given, 
```