### PR TITLE
错误提示信息增加可设置按验证器规则类型进行设置

### DIFF
--- a/src/think/Validate.php
+++ b/src/think/Validate.php
@@ -1584,6 +1584,8 @@ class Validate
             $msg = $this->message[$attribute][$type];
         } elseif (isset($this->message[$attribute])) {
             $msg = $this->message[$attribute];
+        } elseif (isset($this->message[$type])) {
+            $msg = $this->message[$type];
         } elseif (isset($this->typeMsg[$type])) {
             $msg = $this->typeMsg[$type];
         } elseif (str_starts_with($type, 'require')) {


### PR DESCRIPTION
业务场景中可能存在统一按验证器规则或自定义验证进行设置错误提示.

例如需要统一设置 require 的提示信息 或自定义或单独自定义设置错误信息.

```
class ProductValidate extends Validate
{
    protected $rule = [
        'name' => 'require|checkLength',
        'en_name' => 'require|checkLength',
    ];

    protected $field = [
        'name' => '产品中文名称',
        'en_name' => '产品英文名称',
    ];

    protected $message = [
        'require' => '请输入:attribute',
        'en_name.checkLength' => '请输入:attribute, 内容不能为空',
        'checkLength' => '输入的内容不能为空',
    ];

    protected function checkLength($value, $rule, array $data = []): bool
    {
        $value = trim($value);
        return mb_strlen($value) == 0;
    }

}


```