### PR TITLE
修正自动侦测浏览器语言

### DIFF
--- a/library/think/Lang.php
+++ b/library/think/Lang.php
@@ -208,9 +208,8 @@ class Lang
         } elseif (isset($_COOKIE[$this->langCookieVar])) {
             // Cookie中设置了语言变量
             $langSet = strtolower($_COOKIE[$this->langCookieVar]);
-        } elseif (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+        } elseif (isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) && preg_match('/^([a-z\d\-]+)/i', $_SERVER['HTTP_ACCEPT_LANGUAGE'], $matches)) {
             // 自动侦测浏览器语言
-            preg_match('/^([a-z\d\-]+)/i', $_SERVER['HTTP_ACCEPT_LANGUAGE'], $matches);
             $langSet = strtolower($matches[1]);
             if (isset($this->acceptLanguage[$langSet])) {
                 $langSet = $this->acceptLanguage[$langSet];


### PR DESCRIPTION
当 `Accept-Language: *` 时，正则匹配失败，后面没有判断就直接使用 `$matches[1]` ，报下标 `1` 不存在。 最近 PC 微信进行了更新，可能会导致很多旧网站出现此问题。