### PR TITLE
完善 \think\facade\Log 里的方法参数类型注释

### DIFF
--- a/src/think/facade/Log.php
+++ b/src/think/facade/Log.php
@@ -32,16 +32,16 @@ use think\log\ChannelSet;
  * @method static \think\Log record(mixed $msg, string $type = 'info', array $context = [], bool $lazy = true) 记录日志信息
  * @method static \think\Log write(mixed $msg, string $type = 'info', array $context = []) 实时写入日志信息
  * @method static Event listen($listener) 注册日志写入事件监听
- * @method static void log(string $level, mixed $message, array $context = []) 记录日志信息
- * @method static void emergency(mixed $message, array $context = []) 记录emergency信息
- * @method static void alert(mixed $message, array $context = []) 记录警报信息
- * @method static void critical(mixed $message, array $context = []) 记录紧急情况
- * @method static void error(mixed $message, array $context = []) 记录错误信息
- * @method static void warning(mixed $message, array $context = []) 记录warning信息
- * @method static void notice(mixed $message, array $context = []) 记录notice信息
- * @method static void info(mixed $message, array $context = []) 记录一般信息
- * @method static void debug(mixed $message, array $context = []) 记录调试信息
- * @method static void sql(mixed $message, array $context = []) 记录sql信息
+ * @method static void log(string $level, string|\Stringable $message, array $context = []) 记录日志信息
+ * @method static void emergency(string|\Stringable $message, array $context = []) 记录emergency信息
+ * @method static void alert(string|\Stringable $message, array $context = []) 记录警报信息
+ * @method static void critical(string|\Stringable $message, array $context = []) 记录紧急情况
+ * @method static void error(string|\Stringable $message, array $context = []) 记录错误信息
+ * @method static void warning(string|\Stringable $message, array $context = []) 记录warning信息
+ * @method static void notice(string|\Stringable $message, array $context = []) 记录notice信息
+ * @method static void info(string|\Stringable $message, array $context = []) 记录一般信息
+ * @method static void debug(string|\Stringable $message, array $context = []) 记录调试信息
+ * @method static void sql(string|\Stringable $message, array $context = []) 记录sql信息
  * @method static mixed __call($method, $parameters)
  */
 class Log extends Facade


### PR DESCRIPTION
原本是标注为 `mixed` 类型，但实际只支持 `string|\Stringable`。注释标注错误，导致参数传入错误的数据类型时 IDE 未提示