### PR TITLE
标签内的缓存标识列表为空时，不调用 clearTag 方法

### DIFF
--- a/src/think/cache/TagSet.php
+++ b/src/think/cache/TagSet.php
@@ -109,8 +109,8 @@ class TagSet
     {
         // 指定标签清除
         foreach ($this->tag as $tag) {
-            $names = $this->handler->getTagItems($tag);
-            $this->handler->clearTag($names);
+            $keys = $this->handler->getTagItems($tag);
+            if (!empty($keys)) $this->handler->clearTag($keys);
 
             $key = $this->handler->getTagKey($tag);
             $this->handler->delete($key);


### PR DESCRIPTION
#2989 目前清理缓存时，如果对应的缓存标签下没有缓存，会触发报错：
```
ERR wrong number of arguments for 'del' command
```

https://github.com/top-think/framework/blob/aa334db11af944d114d2ec79cd986554ed80c274/src/think/cache/TagSet.php#L103-L120

https://github.com/top-think/framework/blob/aa334db11af944d114d2ec79cd986554ed80c274/src/think/cache/driver/Redis.php#L205-L215

