### PR TITLE
修正多应用路由读取路径

### DIFF
--- a/src/think/console/command/RouteList.php
+++ b/src/think/console/command/RouteList.php
@@ -60,7 +60,7 @@ class RouteList extends Command
         $this->app->route->lazy(false);
 
         if ($dir) {
-            $path = $this->app->getRootPath() . 'route' . DIRECTORY_SEPARATOR . $dir . DIRECTORY_SEPARATOR;
+            $path = $this->app->getAppPath() . $dir . DIRECTORY_SEPARATOR . 'route' . DIRECTORY_SEPARATOR;
         } else {
             $path = $this->app->getRootPath() . 'route' . DIRECTORY_SEPARATOR;
         }


### PR DESCRIPTION
现在 `输出路由定义` 命令的路由读取与实际和文档的不一致，导致无法正确输出多应用的路由定义。

多应用扩展中，路由配置路径为 `$this->app->getAppPath() . 'route' . DIRECTORY_SEPARATOR`
https://github.com/top-think/think-multi-app/blob/master/src/MultiApp.php#L55-L63

官方文档中的路径也是应用目录下的 `route` 目录
![image](https://github.com/top-think/framework/assets/9215157/e6ff9680-93ea-4472-9e58-115a722d3936)

