### PR TITLE
修正 $key 未编码导致的异常页面 XSS 漏洞(ThinkPHP 6.1)

### DIFF
--- a/src/tpl/think_exception.tpl
+++ b/src/tpl/think_exception.tpl
@@ -68,7 +68,7 @@ if (!function_exists('parse_args')) {
                     break;
             }
 
-            $result[] = is_int($key) ? $value : "'{$key}' => {$value}";
+            $result[] = is_int($key) ? $value : sprintf('\'%s\' => %s', htmlentities($key), $value);
         }
 
         return implode(', ', $result);


### PR DESCRIPTION
修正异常页面的 XSS 漏洞
```http
GET http://127.0.0.1:8080/?%3Cscript%3Eeval(atob(`YWxlcnQoJzEyMycp`))%3C/script%3E=1
```

```php
<?php

namespace app\controller;

class Index
{
    public function index(array $params)
    {
    }
}
```