### PR TITLE
RuleGroup.php - 修复指定路由分组调度器时，多个路由分组情况下路由处理错误

### DIFF
--- a/src/think/route/RuleGroup.php
+++ b/src/think/route/RuleGroup.php
@@ -66,8 +66,8 @@ class RuleGroup extends Rule
     {
         $this->router = $router;
         $this->parent = $parent;
-        $this->rule   = $rule;
-        $this->name   = trim($name, '/');
+        $this->rule = $rule;
+        $this->name = trim($name, '/');
 
         $this->setFullName();
 
@@ -145,7 +145,7 @@ class RuleGroup extends Rule
 
         // 获取当前路由规则
         $method = strtolower($request->method());
-        $rules  = $this->getRules($method);
+        $rules = $this->getRules($method);
         $option = $this->getOption();
 
         if (isset($option['complete_match'])) {
@@ -256,8 +256,8 @@ class RuleGroup extends Rule
      */
     protected function checkMergeRuleRegex(Request $request, array &$rules, string $url, bool $completeMatch)
     {
-        $depr  = $this->config('pathinfo_depr');
-        $url   = $depr . str_replace('|', $depr, $url);
+        $depr = $this->config('pathinfo_depr');
+        $url = $depr . str_replace('|', $depr, $url);
         $regex = [];
         $items = [];
 
@@ -292,7 +292,7 @@ class RuleGroup extends Rule
                 if (preg_match_all('/[' . $slash . ']?<?\w+\??>?/', $rule, $matches)) {
                     unset($rules[$key]);
                     $pattern = array_merge($this->getPattern(), $item->getPattern());
-                    $option  = array_merge($this->getOption(), $item->getOption());
+                    $option = array_merge($this->getOption(), $item->getOption());
 
                     $regex[$key] = $this->buildRuleRegex($rule, $matches[0], $pattern, $option, $complete, '_THINK_' . $key);
                     $items[$key] = $item;
@@ -329,7 +329,7 @@ class RuleGroup extends Rule
                 }
             }
 
-            $rule  = $items[$pos]->getRule();
+            $rule = $items[$pos]->getRule();
             $array = $this->router->getRule($rule);
 
             foreach ($array as $item) {
@@ -356,8 +356,8 @@ class RuleGroup extends Rule
     public function miss(string|Closure $route, string $method = '*'): RuleItem
     {
         // 创建路由规则实例
-        $method     =   strtolower($method);
-        $ruleItem   =   new RuleItem($this->router, $this, null, '', $route, $method);
+        $method = strtolower($method);
+        $ruleItem = new RuleItem($this->router, $this, null, '', $route, $method);
 
         $this->miss[$method] = $ruleItem->setMiss();
 

--- a/src/think/route/RuleGroup.php
+++ b/src/think/route/RuleGroup.php
@@ -170,9 +170,7 @@ class RuleGroup extends Rule
             }
         }
 
-        if (!empty($option['dispatcher'])) {
-            $result = $this->parseRule($request, '', $option['dispatcher'], $url, $option);
-        } elseif ($miss = $this->getMissRule($method)) {
+        if ($miss = $this->getMissRule($method)) {
             // 未匹配所有路由的路由规则处理
             $result = $miss->parseRule($request, '', $miss->getRoute(), $url, $miss->getOption());
         } else {


### PR DESCRIPTION
根据断点调试，发现在递归处理路由匹配时，如果第一个分组中没有匹配的路由，且这个路由分组指定了调度器，就会把调度器类当做控制器去解析、执行，直接报错；导致后面有正确的路由无法继续。

可用如下的路由配置复现：
```php
Route::group(function(){
	Route::get('index', 'web.index2/index');
})->dispatcher(\think\route\dispatch\Controller::class);
Route::get('index2', 'web.index2/index');
Route::get('index3', 'web.index2/index');
```
访问/index是没有问题，访问/index2时就会出现上面描述的情况
![Uploading 微信截图_20240722110553.png…]()


---

我的修复建议是删除RuleGroup.php中的这段代码：
https://github.com/top-think/framework/blob/afd7222c0832d3cc029c07a9106dd4fb37cf68d1/src/think/route/RuleGroup.php#L173-L175
```php
if (!empty($option['dispatcher'])) {
       $result = $this->parseRule($request, '', $option['dispatcher'], $url, $option);
}
```
毕竟原版的这段代码与路由调度器的使用方式、作用并不匹配
