### PR TITLE
可以通过环境变量指定环境变量标识

### DIFF
--- a/src/think/App.php
+++ b/src/think/App.php
@@ -440,7 +440,7 @@ class App extends Container
         $this->beginTime = microtime(true);
         $this->beginMem  = memory_get_usage();
 
-        $this->loadEnv($this->envName ?: $this->env->get('env_name', ''));
+        $this->loadEnv($this->envName ?: (string)$this->env->get('env_name'));
 
         $this->configExt = $this->env->get('config_ext', '.php');
 

--- a/src/think/App.php
+++ b/src/think/App.php
@@ -440,7 +440,7 @@ class App extends Container
         $this->beginTime = microtime(true);
         $this->beginMem  = memory_get_usage();
 
-        $this->loadEnv($this->envName);
+        $this->loadEnv($this->envName ?: $this->env->get('env_name', ''));
 
         $this->configExt = $this->env->get('config_ext', '.php');
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -148,6 +148,7 @@ class AppTest extends TestCase
         $env->shouldReceive('load')->once()->with($rootPath . '.env');
         $env->shouldReceive('get')->once()->with('config_ext', '.php')->andReturn('.php');
         $env->shouldReceive('get')->once()->with('app_debug')->andReturn($debug);
+        $env->shouldReceive('get')->once()->with('env_name')->andReturn('');
 
         $event = m::mock(Event::class);
         $event->shouldReceive('trigger')->once()->with(AppInit::class);


### PR DESCRIPTION
现在环境变量标识只能改动入口文件，没这么方便。当未指定环境变量标识时，可以尝试从环境变量中获取，增加了灵活性。