### PR TITLE
编码规范调整为 PER-CS2.0，并使用 php-cs-fixer 进行检查

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,0 +1,31 @@
+name: PHP CS Fixer
+
+on:
+  pull_request:
+    branches:
+      - "8.0"
+    paths:
+      - '**.php'
+
+jobs:
+  php-cs-fixer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 10
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          tools: cs2pr,php-cs-fixer
+
+      - name: Run PHP CS Fixer
+        run: |
+          changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- '*.php')
+          for file in $changed_files; do
+            php-cs-fixer fix "$file" --dry-run --diff --rules=@PER-CS2.0 --format=checkstyle | cs2pr
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,11 @@ ThinkPHP 目前使用 Git 来控制程序版本，如果你想为 ThinkPHP 贡�
 
 ### 注意事项
 
-* 本项目代码格式化标准选用 [**PSR-2**](http://www.kancloud.cn/thinkphp/php-fig-psr/3141)；
+* 本项目代码格式化标准选用 [**PER-CS2.0**](https://cs.symfony.com/doc/ruleSets/PER-CS2.0.html)；
 * 类名和类文件名遵循 [**PSR-4**](http://www.kancloud.cn/thinkphp/php-fig-psr/3144)；
 * 对于 Issues 的处理，请使用诸如 `fix #xxx(Issue ID)` 的 commit title 直接关闭 issue。
-* 系统会自动在 PHP 7.1 ~ 7.3 上测试修改，请确保你的修改符合 PHP 7.1 ~ 7.3 的语法规范；
-* 管理员不会合并造成 CI faild 的修改，若出现 CI faild 请检查自己的源代码或修改相应的[单元测试文件](tests)；
+* 系统会自动在 PHP 8.0 ~ 8.3 版本上测试修改，请确保你的修改符合 PHP 版本的语法规范；
+* 管理员不会合并造成 CI Failed 的修改，若出现 CI Failed 请检查自己的源代码或修改相应的[单元测试文件](tests)；
 
 ## GitHub Issue
 
@@ -77,14 +77,14 @@ GitHub 提供了 Issue 功能，该功能可以用于：
 
 ### 开发环境
 
-* XAMPP for Windows 5.5.x
-* WampServer (for Windows)
-* upupw Apache PHP5.4 ( for Windows)
+* [XAMPP](https://www.apachefriends.org/zh_cn/download.html) - Windows、Linux、Mac OS
+* [WampServer](https://www.apachefriends.org/zh_cn/download.html) - Windows
+* Docker - Windows、Linux、Mac OS
 
 或自行安装
 
 - Apache / Nginx
-- PHP 7.1 ~ 7.3
+- PHP 8.0 ~ 8.3
 - MySQL / MariaDB
 
 *Windows 用户推荐添加 PHP bin 目录到 PATH，方便使用 composer*
@@ -109,7 +109,7 @@ phpfmt 插件参数
 }
 ```
 
-或其他 编辑器 / IDE 配合 PSR2 自动格式化工具
+或其他 编辑器 / IDE 配合自动格式化工具
 
 ### Git GUI
 

--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,8 @@
     "prefer-stable": true,
     "config": {
         "sort-packages": true
+    },
+    "scripts": {
+        "php-cs-fixer": "php-cs-fixer fix src/ --rules=@PER-CS2.0 --dry-run --diff"
     }
 }


### PR DESCRIPTION
对于不符合规范的文件，会在文件头部进行提示：
![image](https://github.com/user-attachments/assets/5607c086-458e-4fea-b735-ad218236989f)

如果需要知道详细，需要运行：
```bash
php-cs-fixer fix src/helper.php --rules=@PER-CS2.0 --dry-run --diff
```