### PR TITLE
优化对 Phar 的支持 #3049

### DIFF
--- a/src/think/App.php
+++ b/src/think/App.php
@@ -540,7 +540,9 @@ class App extends Container
 
         if (is_dir($configPath)) {
             foreach (scandir($configPath) as $name) {
-                if (!str_ends_with($name, $this->configExt) || !is_file($configPath . $name)) continue;
+                if (!str_ends_with($name, $this->configExt) || !is_file($configPath . $name)) {
+                    continue;
+                }
 
                 $this->config->load($configPath . $name, pathinfo($name, PATHINFO_FILENAME));
             }

--- a/src/think/App.php
+++ b/src/think/App.php
@@ -173,7 +173,7 @@ class App extends Container
      */
     public function __construct(string $rootPath = '')
     {
-        $this->thinkPath   = realpath(dirname(__DIR__)) . DIRECTORY_SEPARATOR;
+        $this->thinkPath   = dirname(__DIR__) . DIRECTORY_SEPARATOR;
         $this->rootPath    = $rootPath ? rtrim($rootPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR : $this->getDefaultRootPath();
         $this->appPath     = $this->rootPath . 'app' . DIRECTORY_SEPARATOR;
         $this->runtimePath = $this->rootPath . 'runtime' . DIRECTORY_SEPARATOR;
@@ -538,14 +538,12 @@ class App extends Container
 
         $configPath = $this->getConfigPath();
 
-        $files = [];
-
         if (is_dir($configPath)) {
-            $files = glob($configPath . '*' . $this->configExt);
-        }
+            foreach (scandir($configPath) as $name) {
+                if (!str_ends_with($name, $this->configExt) || !is_file($configPath . $name)) continue;
 
-        foreach ($files as $file) {
-            $this->config->load($file, pathinfo($file, PATHINFO_FILENAME));
+                $this->config->load($configPath . $name, pathinfo($name, PATHINFO_FILENAME));
+            }
         }
 
         if (is_file($appPath . 'event.php')) {

--- a/src/think/Http.php
+++ b/src/think/Http.php
@@ -229,9 +229,10 @@ class Http
         $routePath = $this->getRoutePath();
 
         if (is_dir($routePath)) {
-            $files = glob($routePath . '*.php');
-            foreach ($files as $file) {
-                include $file;
+            foreach (scandir($routePath) as $name) {
+                if (!str_ends_with($name, '.php') || !is_file($routePath . $name)) continue;
+
+                include $routePath . $name;
             }
         }
 

--- a/src/think/Http.php
+++ b/src/think/Http.php
@@ -1,4 +1,5 @@
 <?php
+
 // +----------------------------------------------------------------------
 // | ThinkPHP [ WE CAN DO IT JUST THINK ]
 // +----------------------------------------------------------------------
@@ -230,7 +231,9 @@ class Http
 
         if (is_dir($routePath)) {
             foreach (scandir($routePath) as $name) {
-                if (!str_ends_with($name, '.php') || !is_file($routePath . $name)) continue;
+                if (!str_ends_with($name, '.php') || !is_file($routePath . $name)) {
+                    continue;
+                }
 
                 include $routePath . $name;
             }

--- a/src/think/Lang.php
+++ b/src/think/Lang.php
@@ -137,8 +137,22 @@ class Lang
         ]);
 
         // 加载系统语言包
-        $files = glob($this->app->getAppPath() . 'lang' . DIRECTORY_SEPARATOR . $langset . '.*');
-        $this->load($files);
+        $appLangDir = $this->app->getAppPath() . 'lang' . DIRECTORY_SEPARATOR;
+        if (is_dir($appLangDir)) {
+            $files = [];
+
+            foreach (scandir($appLangDir) as $name) {
+                $path = $appLangDir . $name;
+
+                if (!str_starts_with($name, $langset) || !is_file($path) || !in_array(pathinfo($name, PATHINFO_EXTENSION), ['php', 'yaml', 'json'])) {
+                    continue;
+                }
+
+                $files[] = $path;
+            }
+
+            $this->load($files);
+        }
 
         // 加载扩展（自定义）语言包
         $list = $this->app->config->get('lang.extend_list', []);

--- a/src/think/log/driver/File.php
+++ b/src/think/log/driver/File.php
@@ -137,7 +137,9 @@ class File implements LogHandlerInterface
         if ($this->config['max_files']) {
             $files = [];
             foreach (scandir($this->config['path']) as $name) {
-                if (!str_ends_with($name, '.log') || !is_file($this->config['path'] . $name)) continue;
+                if (!str_ends_with($name, '.log') || !is_file($this->config['path'] . $name)) {
+                    continue;
+                }
 
                 $files[] = $this->config['path'] . $name;
             }

--- a/src/think/log/driver/File.php
+++ b/src/think/log/driver/File.php
@@ -135,7 +135,12 @@ class File implements LogHandlerInterface
     {
 
         if ($this->config['max_files']) {
-            $files = glob($this->config['path'] . '*.log');
+            $files = [];
+            foreach (scandir($this->config['path']) as $name) {
+                if (!str_ends_with($name, '.log') || !is_file($this->config['path'] . $name)) continue;
+
+                $files[] = $this->config['path'] . $name;
+            }
 
             try {
                 if (count($files) > $this->config['max_files']) {


### PR DESCRIPTION

1.`realpath(dirname(__DIR__))` 变为了 `dirname(__DIR__)`（`__DIR__` 获得的变量已是绝对路径？）
2. `glob()` 函数改为用 `scandir()` 实现
3. 加载多语言时，后缀由不限改为`php/yaml/json`（与[手册](https://doc.thinkphp.cn/v8_0/lang.html#%E8%AF%AD%E8%A8%80%E6%96%87%E4%BB%B6%E5%AE%9A%E4%B9%89)对齐）
