### PR TITLE
支持忽略反序列化数据时的异常 #3056

### DIFF
--- a/src/think/cache/driver/File.php
+++ b/src/think/cache/driver/File.php
@@ -1,4 +1,5 @@
 <?php
+
 // +----------------------------------------------------------------------
 // | ThinkPHP [ WE CAN DO IT JUST THINK ]
 // +----------------------------------------------------------------------
@@ -8,7 +9,7 @@
 // +----------------------------------------------------------------------
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
-declare (strict_types = 1);
+declare (strict_types=1);
 
 namespace think\cache\driver;
 
@@ -135,7 +136,7 @@ class File extends Driver
     {
         $raw = $this->getRaw($name);
 
-        return is_null($raw) ? $default : $this->unserialize($raw['content']);
+        return is_null($raw) ? $default : $this->unserialize($raw['content'], $name, $default);
     }
 
     /**
@@ -199,7 +200,7 @@ class File extends Driver
     public function inc($name, $step = 1)
     {
         if ($raw = $this->getRaw($name)) {
-            $value  = $this->unserialize($raw['content']) + $step;
+            $value  = $this->unserialize($raw['content'], $name, 0) + $step;
             $expire = $raw['expire'];
         } else {
             $value  = $step;

--- a/src/think/cache/driver/Memcache.php
+++ b/src/think/cache/driver/Memcache.php
@@ -1,4 +1,5 @@
 <?php
+
 // +----------------------------------------------------------------------
 // | ThinkPHP [ WE CAN DO IT JUST THINK ]
 // +----------------------------------------------------------------------
@@ -8,7 +9,7 @@
 // +----------------------------------------------------------------------
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
-declare (strict_types = 1);
+declare (strict_types=1);
 
 namespace think\cache\driver;
 
@@ -52,7 +53,7 @@ class Memcache extends Driver
             $this->options = array_merge($this->options, $options);
         }
 
-        $this->handler = new \Memcache;
+        $this->handler = new \Memcache();
 
         // 支持集群
         $hosts = (array) $this->options['host'];
@@ -95,7 +96,7 @@ class Memcache extends Driver
     {
         $result = $this->handler->get($this->getCacheKey($name));
 
-        return false !== $result ? $this->unserialize($result) : $default;
+        return false !== $result ? $this->unserialize($result, $name, $default) : $default;
     }
 
     /**

--- a/src/think/cache/driver/Memcached.php
+++ b/src/think/cache/driver/Memcached.php
@@ -1,4 +1,5 @@
 <?php
+
 // +----------------------------------------------------------------------
 // | ThinkPHP [ WE CAN DO IT JUST THINK ]
 // +----------------------------------------------------------------------
@@ -8,7 +9,7 @@
 // +----------------------------------------------------------------------
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
-declare (strict_types = 1);
+declare (strict_types=1);
 
 namespace think\cache\driver;
 
@@ -53,7 +54,7 @@ class Memcached extends Driver
             $this->options = array_merge($this->options, $options);
         }
 
-        $this->handler = new \Memcached;
+        $this->handler = new \Memcached();
 
         if (!empty($this->options['option'])) {
             $this->handler->setOptions($this->options['option']);
@@ -109,7 +110,7 @@ class Memcached extends Driver
     {
         $result = $this->handler->get($this->getCacheKey($name));
 
-        return false !== $result ? $this->unserialize($result) : $default;
+        return false !== $result ? $this->unserialize($result, $name, $default) : $default;
     }
 
     /**

--- a/src/think/cache/driver/Redis.php
+++ b/src/think/cache/driver/Redis.php
@@ -1,4 +1,5 @@
 <?php
+
 // +----------------------------------------------------------------------
 // | ThinkPHP [ WE CAN DO IT JUST THINK ]
 // +----------------------------------------------------------------------
@@ -8,7 +9,7 @@
 // +----------------------------------------------------------------------
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
-declare (strict_types = 1);
+declare (strict_types=1);
 
 namespace think\cache\driver;
 
@@ -54,7 +55,7 @@ class Redis extends Driver
     {
         if (!$this->handler) {
             if (extension_loaded('redis')) {
-                $this->handler = new \Redis;
+                $this->handler = new \Redis();
 
                 if ($this->options['persistent']) {
                     $this->handler->pconnect($this->options['host'], (int) $this->options['port'], (int) $this->options['timeout'], 'persistent_id_' . $this->options['select']);
@@ -120,7 +121,7 @@ class Redis extends Driver
             return $default;
         }
 
-        return $this->unserialize($value);
+        return $this->unserialize($value, $name, $value);
     }
 
     /**
@@ -243,5 +244,5 @@ class Redis extends Driver
     public function __call($method, $args)
     {
         return call_user_func_array([$this->handler(), $method], $args);
-    }    
+    }
 }

--- a/src/think/cache/driver/Wincache.php
+++ b/src/think/cache/driver/Wincache.php
@@ -1,4 +1,5 @@
 <?php
+
 // +----------------------------------------------------------------------
 // | ThinkPHP [ WE CAN DO IT JUST THINK ]
 // +----------------------------------------------------------------------
@@ -8,7 +9,7 @@
 // +----------------------------------------------------------------------
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
-declare (strict_types = 1);
+declare (strict_types=1);
 
 namespace think\cache\driver;
 
@@ -75,7 +76,7 @@ class Wincache extends Driver
     {
         $key = $this->getCacheKey($name);
 
-        return wincache_ucache_exists($key) ? $this->unserialize(wincache_ucache_get($key)) : $default;
+        return wincache_ucache_exists($key) ? $this->unserialize(wincache_ucache_get($key), $name, $default) : $default;
     }
 
     /**


### PR DESCRIPTION
支持反序列化缓存数据时，忽略异常，提高缓存可用性。

在缓存配置中，把 `stores.file.serialize[2]` 设置为 `true` 时，反序列化缓存数据失败则不抛出异常，然后删除缓存，最后返回默认值。