### PR TITLE
去除旧版的静态获取TP版本，以免混淆

### DIFF
--- a/src/think/App.php
+++ b/src/think/App.php
@@ -39,8 +39,6 @@ use think\initializer\RegisterService;
  */
 class App extends Container
 {
-    const VERSION = '8.0.0';
-
     /**
      * 应用调试模式
      * @var bool


### PR DESCRIPTION
首选这个版本变量也不更新了，方法也改成composer获取TP版本了
所以去除旧版的静态获取TP版本，有些人会从app.php里面看版本，以免混淆一直以为下载的旧版本8.0.0