### PR TITLE
路由Rule支持 `append、middleware`方法多次调用

### DIFF
--- a/src/think/route/Rule.php
+++ b/src/think/route/Rule.php
@@ -461,7 +461,7 @@ abstract class Rule
      */
     public function append(array $append = [])
     {
-        $this->option['append'] = $append;
+        $this->option['append'] = array_merge($this->option['append'] ?? [], $append);
 
         return $this;
     }
@@ -492,7 +492,7 @@ abstract class Rule
     public function middleware(string | array | Closure $middleware, ...$params)
     {
         if (empty($params) && is_array($middleware)) {
-            $this->option['middleware'] = $middleware;
+            $this->option['middleware'] = array_merge($this->option['middleware'] ?? [], $middleware);
         } else {
             foreach ((array) $middleware as $item) {
                 $this->option['middleware'][] = [$item, $params];


### PR DESCRIPTION
append在tp5是可以多次调用的，从tp6以后，做了一些减法，我觉得没必要。又不是什么复杂的代码，有与没有都不影响框架的复杂度，却影响了使用体验。我做cms系统，动态生成路由的时候同一个路由有多个步骤，需要多次append参数。搞得有点繁琐了，我只能把每步需要append的参数暂存起来，最后再一次的调用append。现有的框架代码只考虑人工手写路由的情形，觉得没有人会多次append。