### PR TITLE
优化 Cookie 设置（数组 key 为字符串数值时，PHP 会自动转换为 int）

### DIFF
--- a/src/think/Cookie.php
+++ b/src/think/Cookie.php
@@ -1,14 +1,15 @@
 <?php
+
 // +----------------------------------------------------------------------
 // | ThinkPHP [ WE CAN DO IT JUST THINK ]
 // +----------------------------------------------------------------------
-// | Copyright (c) 2006~2023 http://thinkphp.cn All rights reserved.
+// | Copyright (c) 2006~2024 http://thinkphp.cn All rights reserved.
 // +----------------------------------------------------------------------
 // | Licensed ( http://www.apache.org/licenses/LICENSE-2.0 )
 // +----------------------------------------------------------------------
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
-declare (strict_types = 1);
+declare (strict_types=1);
 
 namespace think;
 
@@ -183,14 +184,14 @@ class Cookie
             [$value, $expire, $option] = $val;
 
             $this->saveCookie(
-                $name,
+                (string) $name,
                 $value,
                 $expire,
                 $option['path'],
                 $option['domain'],
-                $option['secure'] ? true : false,
-                $option['httponly'] ? true : false,
-                $option['samesite']
+                (bool) $option['secure'],
+                (bool) $option['httponly'],
+                $option['samesite'],
             );
         }
     }


### PR DESCRIPTION
`$this->cookie` 的 key 为字符串数值时，PHP 会自动转换为 int
```
    /**
     * 保存Cookie
     * @access public
     * @return void
     */
    public function save(): void
    {
        foreach ($this->cookie as $name => $val) {
            [$value, $expire, $option] = $val;

            $this->saveCookie(
                (string)$name,
                $value,
                $expire,
                $option['path'],
                $option['domain'],
                (bool)$option['secure'],
                (bool)$option['httponly'],
                $option['samesite']
            );
        }
    }
```