### PR TITLE
fix implicitly marking parameter $namespace as nullable is deprecated  in PHP8.4

### DIFF
--- a/src/think/Console.php
+++ b/src/think/Console.php
@@ -596,7 +596,7 @@ class Console
      * @return Command[]
      * @api
      */
-    public function all(?string $namespace = null): array
+    public function all(string|null $namespace = null): array
     {
         if (null === $namespace) {
             return $this->commands;


### PR DESCRIPTION
think\exception\ErrorException: think\Console::all(): Implicitly marking parameter $namespace as nullable is deprecated, the explicit nullable type must be used instead

/home/runner/work/think-authz/think-authz/vendor/topthink/framework/src/think/Console.php:599
/home/runner/work/think-authz/think-authz/vendor/topthink/framework/src/think/Service.php:59
/home/runner/work/think-authz/think-authz/vendor/topthink/think-migration/src/Service.php:40