### PR TITLE
fix: 路由组设置了中间件等，但子路由没有设置时，合并问题

### DIFF
--- a/src/think/route/Rule.php
+++ b/src/think/route/Rule.php
@@ -310,9 +310,7 @@ abstract class Rule
 
             // 合并分组参数
             foreach ($this->mergeOptions as $item) {
-                if (isset($parentOption[$item]) && isset($option[$item])) {
-                    $option[$item] = array_merge($parentOption[$item], $option[$item]);
-                }
+                $option[$item] = array_merge($parentOption[$item] ?? [], $option[$item] ?? []);
             }
 
             $option = array_merge($parentOption, $option);


### PR DESCRIPTION
![1751207542410](https://github.com/user-attachments/assets/0592c4a5-123d-4887-b785-44ec673efa32)

在路由组设置了中间件，但是子路由没有设置时候，getOption合并的判断逻辑存在问题，不会进行合并