### PR TITLE
修复在PHP8.5下异常报错

### DIFF
--- a/src/think/route/Dispatch.php
+++ b/src/think/route/Dispatch.php
@@ -185,7 +185,9 @@ abstract class Dispatch
 
         if ($class->hasProperty('middleware')) {
             $reflectionProperty = $class->getProperty('middleware');
-            $reflectionProperty->setAccessible(true);
+            if (PHP_VERSION_ID < 80100) {
+                $reflectionProperty->setAccessible(true);
+            }
 
             $middlewares = $reflectionProperty->getValue($controller);
             $action      = $this->request->action(true);


### PR DESCRIPTION
修复在PHP8.5下异常报错
Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect PHP 8.1 及之后，PHP 引入了属性访问的新机制，反射访问私有属性不再需要通过 setAccessible(true) 开启，该方法的调用变得多余，因此在 PHP 8.5 中被正式弃用。 通过版本判断兼容版本低于PHP8.1的使用环境。