### PR TITLE
优化 url 生成

### DIFF
--- a/src/think/route/Url.php
+++ b/src/think/route/Url.php
@@ -224,6 +224,11 @@ class Url
             }
         }
 
+        $ext = pathinfo($url, PATHINFO_EXTENSION);
+        if ('' !== $ext && str_ends_with($url, '.' . $ext)) {
+            $url = substr($url, 0, -strlen($ext) - 1);
+        }
+
         return $url;
     }
 

--- a/tests/UrlRouteTest.php
+++ b/tests/UrlRouteTest.php
@@ -42,6 +42,21 @@ class UrlRouteTest extends TestCase
     }
 
     /**
+     * 测试 Route::buildUrl()
+     */
+    public function testBuild()
+    {
+        $request  = $this->makeRequest('index/index.html');
+
+        $this->app->request = $request;
+
+        $urlBuild = new \think\route\Url($this->route, $this->app, '', []);
+        $result = $urlBuild->build();
+
+        $this->assertEquals('/index/index.html', $result);
+    }
+
+    /**
      * @param        $path
      * @param string $method
      * @param string $host


### PR DESCRIPTION
修正 PATH_INFO 携带后缀时，url() 生成的地址会再次叠加后缀。

### 复现步骤

1.全新安装框架

```bash
composer create-project topthink/think tp
cd tp
php think run
```

2.访问 http://127.0.0.1:8000/index/index.html
3.使用 `url()` 生成 URL 地址，返回
```
/index/index.html.html
```
正常应该返回
```
/index/index.html
```