### PR TITLE
feat: run 命令支持从 .env 读取 HOST/PORT 配置

### DIFF
--- a/src/think/console/command/RunServer.php
+++ b/src/think/console/command/RunServer.php
@@ -48,8 +48,8 @@ class RunServer extends Command
 
     public function execute(Input $input, Output $output)
     {
-        $host = $input->getOption('host');
-        $port = $input->getOption('port');
+        $host = $input->getOption('host') ?: env('server.host', '0.0.0.0');
+        $port = $input->getOption('port') ?: env('server.port', 8000);
         $root = $input->getOption('root');
         if (empty($root)) {
             $root = $this->app->getRootPath() . 'public';


### PR DESCRIPTION
优先级：命令行参数 > .env > 默认值

.env 配置示例：
[SERVER]
HOST=0.0.0.0
PORT=9000