### PR TITLE
修复并发场景下缓存push操作抛出异常的问题

### DIFF
--- a/src/think/cache/Driver.php
+++ b/src/think/cache/Driver.php
@@ -117,7 +117,7 @@ abstract class Driver implements CacheHandlerInterface
         $item = $this->get($name, []);
 
         if (!is_array($item)) {
-            throw new InvalidArgumentException('only array cache can be push');
+            $item = [];
         }
 
         $item[] = $value;


### PR DESCRIPTION
### 改动内容
think\cache\Driver::push() 方法，将非数组缓存值的处理从抛出异常改为重置为空数组继续执行。

###  收益
- 消除并发场景下的致命错误：Cache::tag()->set() 是框架推荐的标准用法，在并发请求下不再抛出 InvalidArgumentException 导致业务 500
- 改动极小：仅修改 1 行代码，不影响任何公共 API、方法签名、正常场景下的行为
- 所有驱动统一受益：File、Redis、Memcache、Memcached、Wincache 均继承基类 push()，无需逐个处理
- 正常场景零影响：当缓存值为数组时（绝大多数情况），!is_array 分支不走，行为完全不变 
### 注意事项
- tag 集合可能被意外重置：触发容错时，tag 集合从已有索引重置为仅含当前值，之前记录的缓存 key 成为孤儿，Cache::tag()->clear() 可能漏清
- 孤儿缓存需要过期时间兜底：未设置过期时间的孤儿缓存将永久残留，建议使用 tag 缓存时配合合理的过期时间